### PR TITLE
rbuildignore - dot to escaped dot

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -28,10 +28,10 @@
 ^Meta$
 ^outputdir$
 ^scratch$
+^staged_dependencies\.yaml$
 ^stubs$
 ^temp$
 ^templates$
 ^test_full_example$
 ^TODO\.md$
 ^LICENSE\.md$
-^staged_dependencies.yaml$


### PR DESCRIPTION
Update .Rbuildignore for ^stage_dependencies\\.yaml$.

Dot was not escaped