### PR TITLE
devops: removed `test.nest` dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Description: Provides teal modules for the standard clinical trials
     change the encodings within teal.
 License: Apache License 2.0 | file LICENSE
 URL: https://github.com/insightsengineering/teal.modules.clinical
-BugReports: 
+BugReports:
     https://github.com/insightsengineering/teal.modules.clinical/issues
 Depends:
     ggplot2,
@@ -53,9 +53,8 @@ Suggests:
     knitr,
     scda.2021(>= 0.1.1),
     scda(>= 0.1.1),
-    test.nest (>= 0.2.11),
     testthat (>= 2.0)
-VignetteBuilder: 
+VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: true

--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -23,7 +23,4 @@ upstream_repos:
   insightsengineering/teal:
     repo: insightsengineering/teal
     host: https://github.com
-  insightsengineering/test.nest:
-    repo: insightsengineering/test.nest
-    host: https://github.com
 downstream_repos:

--- a/tests/testthat/test_nest.R
+++ b/tests/testthat/test_nest.R
@@ -1,3 +1,0 @@
-library(test.nest)
-
-test_all(importfrom_args = list(skip = c("setNames", "terms")))


### PR DESCRIPTION
Related to insightsengineering/coredev-tasks#70
