### PR TITLE
suggest to add name or attribute to hlt and llt when parsing in

### DIFF
--- a/R/tm_t_events.R
+++ b/R/tm_t_events.R
@@ -21,6 +21,7 @@ template_events <- function(dataname,
                             prune_diff = 0,
                             drop_arm_levels = TRUE,
                             basic_table_args = teal.devel::basic_table_args()) {
+  # browser()
   assertthat::assert_that(
     assertthat::is.string(dataname),
     assertthat::is.string(parentname),
@@ -118,7 +119,7 @@ template_events <- function(dataname,
   parsed_basic_table_args <- teal.devel::parse_basic_table_args(
     teal.devel::resolve_basic_table_args(
       user_table = basic_table_args,
-      module_table = teal.devel::basic_table_args(title = paste("Event Summary of", hlt, llt))
+      module_table = teal.devel::basic_table_args(title = paste("Event Summary of", names(hlt), "in", names(llt)))
     )
   )
 
@@ -704,8 +705,15 @@ srv_t_events_byterm <- function(input,
     teal.devel::chunks_push_data_merge(anl_adsl)
     teal.devel::chunks_push_new_line()
 
+    get_selected_label <- function(obj, current_selected){
+      name_list <- names(obj$select$choices)
+      name_list[obj$select$choices %in% current_selected]
+    }
+
     input_hlt <- as.vector(anl_m$columns_source$hlt)
+    names(input_hlt) <- get_selected_label(hlt, input_hlt)
     input_llt <- as.vector(anl_m$columns_source$llt)
+    names(input_llt) <- get_selected_label(llt, input_llt)
 
     my_calls <- template_events(
       dataname = "ANL",


### PR DESCRIPTION
Hi @yli110-stat697 

just made a small suggestion to your PR for extracting the label names

you maybe also want to put the part of 

```R
input_hlt <- as.vector(anl_m$columns_source$hlt)
    names(input_hlt) <- get_selected_label(hlt, input_hlt)
```

wrapped into the `get_selected_labe`l function as well, so things can be more tidy. 

it needs a bit of thinking of 

1. how to handle as.vector, when you have multiple selections
2. if the there are multiple selected items? is this possible?