### PR TITLE
fix barchart

### DIFF
--- a/R/tm_g_barchart_simple.R
+++ b/R/tm_g_barchart_simple.R
@@ -164,7 +164,8 @@ tm_g_barchart_simple <- function(x = NULL,
   checkmate::assert_numeric(plot_height[1], lower = plot_height[2], upper = plot_height[3], .var.name = "plot_height")
   checkmate::assert_numeric(plot_width, len = 3, any.missing = FALSE, null.ok = TRUE, finite = TRUE)
   checkmate::assert_numeric(
-    plot_width[1], lower = plot_width[2], upper = plot_width[3], null.ok = TRUE, .var.name = "plot_width"
+    plot_width[1],
+    lower = plot_width[2], upper = plot_width[3], null.ok = TRUE, .var.name = "plot_width"
   )
   checkmate::assert_class(pre_output, classes = "shiny.tag", null.ok = TRUE)
   checkmate::assert_class(post_output, classes = "shiny.tag", null.ok = TRUE)


### PR DESCRIPTION
Closes #279 

@pawelru @mhallal1 I think this is a much wider problem than the barchart (and outlier - which I fixed last week) module and needs to be fixed in teal.devel rather than here

If you have a list of data_extract_spec for one data_extract_ui that gets passed into data_merge_module (or data_merge_srv) then the app gives an error if you deselect a dataset:

![image](https://user-images.githubusercontent.com/15201933/150164453-88ff053d-828a-4cec-9390-3d5cc2abf8b3.png)

Even though in a lot of cases it is OK for this to be de-selected (as it is here)

I don't think we see this much as the vast majority of our examples have a single data_extract_spec per data_extract_ui