### PR TITLE
ggplot args docs fix

### DIFF
--- a/R/argument_convention.R
+++ b/R/argument_convention.R
@@ -92,7 +92,7 @@
 #'   The argument is merged with option `teal.ggplot2_args` and with default module arguments
 #'   (hard coded in the module body).
 #'
-#'   For more details, see the help vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
+#'   For more details, see the vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
 #' @name template_arguments
 #'
 NULL

--- a/R/tm_g_forest_rsp.R
+++ b/R/tm_g_forest_rsp.R
@@ -12,11 +12,12 @@
 #'   names of the variables for stratified analysis.
 #' @param ggplot2_args optional, (`ggplot2_args`)\cr
 #' object created by [teal.devel::ggplot2_args()] with settings for the module plot.
-#' For this module, this argument will only accept `labs` arguments such as: `title`, `caption`.
+#' For this module, this argument will only accept `ggplot2_args` object with `labs` list of following child elements:
+#' `title`, `caption`.
 #' No other elements would be taken into account. The argument is merged with option `teal.ggplot2_args` and
 #' with default module arguments (hard coded in the module body).
 #'
-#' For more details, see the help vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
+#' For more details, see the vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
 #'
 #' @seealso [tm_g_forest_rsp()]
 template_forest_rsp <- function(dataname = "ANL",
@@ -200,11 +201,12 @@ template_forest_rsp <- function(dataname = "ANL",
 #' Otherwise, the symbol size will be proportional to the sample size in each each subgroup.
 #' @param ggplot2_args optional, (`ggplot2_args`)\cr
 #' object created by [teal.devel::ggplot2_args()] with settings for the module plot.
-#' For this module, this argument will only accept `labs` arguments such as: `title`, `caption`.
+#' For this module, this argument will only accept `ggplot2_args` object with `labs` list of following child elements:
+#' `title`, `caption`.
 #' No other elements would be taken into account. The argument is merged with option `teal.ggplot2_args` and
 #' with default module arguments (hard coded in the module body).
 #'
-#' For more details, see the help vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
+#' For more details, see the vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
 #'
 #' @export
 #'

--- a/R/tm_g_forest_tte.R
+++ b/R/tm_g_forest_tte.R
@@ -6,11 +6,12 @@
 #' @inheritParams template_forest_rsp
 #' @param ggplot2_args optional, (`ggplot2_args`)\cr
 #' object created by [teal.devel::ggplot2_args()] with settings for the module plot.
-#' For this module, this argument will only accept `labs` arguments such as: `title`, `caption`.
+#' For this module, this argument will only accept `ggplot2_args` object with `labs` list of following child elements:
+#' `title`, `caption`.
 #' No other elements would be taken into account. The argument is merged with option `teal.ggplot2_args` and
 #' with default module arguments (hard coded in the module body).
 #'
-#' For more details, see the help vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
+#' For more details, see the vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
 #'
 #' @seealso [tm_g_forest_tte()]
 template_forest_tte <- function(dataname = "ANL",
@@ -199,11 +200,12 @@ template_forest_tte <- function(dataname = "ANL",
 #' @inheritParams tm_g_forest_rsp
 #' @param ggplot2_args optional, (`ggplot2_args`)\cr
 #' object created by [teal.devel::ggplot2_args()] with settings for the module plot.
-#' For this module, this argument will only accept `labs` arguments such as: `title`, `caption`.
+#' For this module, this argument will only accept `ggplot2_args` object with `labs` list of following child elements:
+#' `title`, `caption`.
 #' No other elements would be taken into account. The argument is merged with option `teal.ggplot2_args` and
 #' with default module arguments (hard coded in the module body).
 #'
-#' For more details, see the help vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
+#' For more details, see the vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
 #'
 #' @export
 #'

--- a/R/tm_g_ipp.R
+++ b/R/tm_g_ipp.R
@@ -13,11 +13,12 @@
 #' @param add_avalu (`flag`)\cr allow user to not display value unit in the plot.
 #' @param ggplot2_args optional, (`ggplot2_args`)\cr
 #' object created by [teal.devel::ggplot2_args()] with settings for the module plot.
-#' For this module, this argument will only accept `labs` arguments such as: `title`, `subtitle`, `x`, `y`.
+#' For this module, this argument will only accept `ggplot2_args` object with `labs` list of following child elements:
+#' `title`, `subtitle`, `x`, `y`.
 #' No other elements would be taken into account. The argument is merged with option `teal.ggplot2_args` and
 #' with default module arguments (hard coded in the module body).
 #'
-#' For more details, see the help vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
+#' For more details, see the vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
 
 template_g_ipp <- function(dataname = "ANL",
                            paramcd,
@@ -174,11 +175,12 @@ template_g_ipp <- function(dataname = "ANL",
 #'   and preselected option for variable values that can be used as `base_var`.
 #' @param ggplot2_args optional, (`ggplot2_args`)\cr
 #' object created by [teal.devel::ggplot2_args()] with settings for the module plot.
-#' For this module, this argument will only accept `labs` arguments such as: `title`, `subtitle`, `x`, `y`.
+#' For this module, this argument will only accept `ggplot2_args` object with `labs` list of following child elements:
+#' `title`, `subtitle`, `x`, `y`.
 #' No other elements would be taken into account. The argument is merged with option `teal.ggplot2_args` and
 #' with default module arguments (hard coded in the module body).
 #'
-#' For more details, see the help vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
+#' For more details, see the vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
 #'
 #' @export
 #'

--- a/R/tm_g_lineplot.R
+++ b/R/tm_g_lineplot.R
@@ -9,11 +9,12 @@
 #'   should the screening visit be included.
 #' @param ggplot2_args optional, (`ggplot2_args`)\cr
 #' object created by [teal.devel::ggplot2_args()] with settings for the module plot.
-#' For this module, this argument will only accept `labs` arguments such as: `title`, `subtitle`, `caption`, `y`, `lty`.
+#' For this module, this argument will only accept `ggplot2_args` object with `labs` list of following child elements:
+#' `title`, `subtitle`, `caption`, `y`, `lty`.
 #' No other elements would be taken into account. The argument is merged with option `teal.ggplot2_args` and
 #' with default module arguments (hard coded in the module body).
 #'
-#' For more details, see the help vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
+#' For more details, see the vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
 #'
 #' @seealso [tm_g_lineplot()]
 template_g_lineplot <- function(dataname = "ANL",
@@ -187,11 +188,12 @@ template_g_lineplot <- function(dataname = "ANL",
 #' @inheritParams module_arguments
 #' @param ggplot2_args optional, (`ggplot2_args`)\cr
 #' object created by [teal.devel::ggplot2_args()] with settings for the module plot.
-#' For this module, this argument will only accept `labs` arguments such as: `title`, `subtitle`, `caption`, `y`, `lty`.
+#' For this module, this argument will only accept `ggplot2_args` object with `labs` list of following child elements:
+#' `title`, `subtitle`, `caption`, `y`, `lty`.
 #' No other elements would be taken into account. The argument is merged with option `teal.ggplot2_args` and
 #' with default module arguments (hard coded in the module body)
 #'
-#' For more details, see the help vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
+#' For more details, see the vignette: `vignette("custom-ggplot2-arguments", package = "teal.devel")`.
 #'
 #' @export
 #'

--- a/man/template_adverse_events.Rd
+++ b/man/template_adverse_events.Rd
@@ -45,7 +45,7 @@ object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args(
 The argument is merged with option \code{teal.ggplot2_args} and with default module arguments
 (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 Creates an adverse events template call.

--- a/man/template_arguments.Rd
+++ b/man/template_arguments.Rd
@@ -123,7 +123,7 @@ object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args(
 The argument is merged with option \code{teal.ggplot2_args} and with default module arguments
 (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 The documentation to this function lists all the arguments in teal module

--- a/man/template_fit_mmrm.Rd
+++ b/man/template_fit_mmrm.Rd
@@ -118,7 +118,7 @@ object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args(
 The argument is merged with option \code{teal.ggplot2_args} and with default module arguments
 (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 Template: Mixed Model Repeated Measurements (MMRM) analysis

--- a/man/template_forest_rsp.Rd
+++ b/man/template_forest_rsp.Rd
@@ -57,11 +57,12 @@ to calculate the estimator. If \code{NULL}, the same symbol size is used for all
 
 \item{ggplot2_args}{optional, (\code{ggplot2_args})\cr
 object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args()}} with settings for the module plot.
-For this module, this argument will only accept \code{labs} arguments such as: \code{title}, \code{caption}.
+For this module, this argument will only accept \code{ggplot2_args} object with \code{labs} list of following child elements:
+\code{title}, \code{caption}.
 No other elements would be taken into account. The argument is merged with option \code{teal.ggplot2_args} and
 with default module arguments (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 Creates a valid expression for response forest plot.

--- a/man/template_forest_tte.Rd
+++ b/man/template_forest_tte.Rd
@@ -62,11 +62,12 @@ name of the variable representing time units.}
 
 \item{ggplot2_args}{optional, (\code{ggplot2_args})\cr
 object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args()}} with settings for the module plot.
-For this module, this argument will only accept \code{labs} arguments such as: \code{title}, \code{caption}.
+For this module, this argument will only accept \code{ggplot2_args} object with \code{labs} list of following child elements:
+\code{title}, \code{caption}.
 No other elements would be taken into account. The argument is merged with option \code{teal.ggplot2_args} and
 with default module arguments (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 Creates a valid expression for survival forest plot.

--- a/man/template_g_ci.Rd
+++ b/man/template_g_ci.Rd
@@ -39,7 +39,7 @@ object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args(
 The argument is merged with option \code{teal.ggplot2_args} and with default module arguments
 (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 Writes the expressions to filter data and draw confidence interval

--- a/man/template_g_ipp.Rd
+++ b/man/template_g_ipp.Rd
@@ -57,11 +57,12 @@ the variable name for subject id.}
 
 \item{ggplot2_args}{optional, (\code{ggplot2_args})\cr
 object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args()}} with settings for the module plot.
-For this module, this argument will only accept \code{labs} arguments such as: \code{title}, \code{subtitle}, \code{x}, \code{y}.
+For this module, this argument will only accept \code{ggplot2_args} object with \code{labs} list of following child elements:
+\code{title}, \code{subtitle}, \code{x}, \code{y}.
 No other elements would be taken into account. The argument is merged with option \code{teal.ggplot2_args} and
 with default module arguments (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 
 \item{suppress_legend}{(\code{flag})\cr allow user to suppress legend}
 

--- a/man/template_g_lineplot.Rd
+++ b/man/template_g_lineplot.Rd
@@ -84,11 +84,12 @@ If it equals to \code{NULL}, then no label will be added.}
 
 \item{ggplot2_args}{optional, (\code{ggplot2_args})\cr
 object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args()}} with settings for the module plot.
-For this module, this argument will only accept \code{labs} arguments such as: \code{title}, \code{subtitle}, \code{caption}, \code{y}, \code{lty}.
+For this module, this argument will only accept \code{ggplot2_args} object with \code{labs} list of following child elements:
+\code{title}, \code{subtitle}, \code{caption}, \code{y}, \code{lty}.
 No other elements would be taken into account. The argument is merged with option \code{teal.ggplot2_args} and
 with default module arguments (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 Template: Line Plot

--- a/man/template_patient_timeline.Rd
+++ b/man/template_patient_timeline.Rd
@@ -57,7 +57,7 @@ object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args(
 The argument is merged with option \code{teal.ggplot2_args} and with default module arguments
 (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 Creates a patient timeline template call.

--- a/man/template_therapy.Rd
+++ b/man/template_therapy.Rd
@@ -54,7 +54,7 @@ object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args(
 The argument is merged with option \code{teal.ggplot2_args} and with default module arguments
 (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 Creates a therapy template call.

--- a/man/template_vitals.Rd
+++ b/man/template_vitals.Rd
@@ -36,7 +36,7 @@ object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args(
 The argument is merged with option \code{teal.ggplot2_args} and with default module arguments
 (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 Creates a vitals template.

--- a/man/tm_g_forest_rsp.Rd
+++ b/man/tm_g_forest_rsp.Rd
@@ -99,11 +99,12 @@ the \code{\link[shiny:helpText]{shiny::helpText()}} elements are useful.}
 
 \item{ggplot2_args}{optional, (\code{ggplot2_args})\cr
 object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args()}} with settings for the module plot.
-For this module, this argument will only accept \code{labs} arguments such as: \code{title}, \code{caption}.
+For this module, this argument will only accept \code{ggplot2_args} object with \code{labs} list of following child elements:
+\code{title}, \code{caption}.
 No other elements would be taken into account. The argument is merged with option \code{teal.ggplot2_args} and
 with default module arguments (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 This teal module produces a grid style Forest plot for response data with ADaM structure.

--- a/man/tm_g_forest_tte.Rd
+++ b/man/tm_g_forest_tte.Rd
@@ -100,11 +100,12 @@ the \code{\link[shiny:helpText]{shiny::helpText()}} elements are useful.}
 
 \item{ggplot2_args}{optional, (\code{ggplot2_args})\cr
 object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args()}} with settings for the module plot.
-For this module, this argument will only accept \code{labs} arguments such as: \code{title}, \code{caption}.
+For this module, this argument will only accept \code{ggplot2_args} object with \code{labs} list of following child elements:
+\code{title}, \code{caption}.
 No other elements would be taken into account. The argument is merged with option \code{teal.ggplot2_args} and
 with default module arguments (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 This teal module produces a grid style Forest plot for time-to-event data

--- a/man/tm_g_ipp.Rd
+++ b/man/tm_g_ipp.Rd
@@ -91,11 +91,12 @@ the \code{\link[shiny:helpText]{shiny::helpText()}} elements are useful.}
 
 \item{ggplot2_args}{optional, (\code{ggplot2_args})\cr
 object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args()}} with settings for the module plot.
-For this module, this argument will only accept \code{labs} arguments such as: \code{title}, \code{subtitle}, \code{x}, \code{y}.
+For this module, this argument will only accept \code{ggplot2_args} object with \code{labs} list of following child elements:
+\code{title}, \code{subtitle}, \code{x}, \code{y}.
 No other elements would be taken into account. The argument is merged with option \code{teal.ggplot2_args} and
 with default module arguments (hard coded in the module body).
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 This teal module produces grid style Individual patient plot(s) that show

--- a/man/tm_g_lineplot.Rd
+++ b/man/tm_g_lineplot.Rd
@@ -107,11 +107,12 @@ the \code{\link[shiny:helpText]{shiny::helpText()}} elements are useful.}
 
 \item{ggplot2_args}{optional, (\code{ggplot2_args})\cr
 object created by \code{\link[teal.devel:ggplot2_args]{teal.devel::ggplot2_args()}} with settings for the module plot.
-For this module, this argument will only accept \code{labs} arguments such as: \code{title}, \code{subtitle}, \code{caption}, \code{y}, \code{lty}.
+For this module, this argument will only accept \code{ggplot2_args} object with \code{labs} list of following child elements:
+\code{title}, \code{subtitle}, \code{caption}, \code{y}, \code{lty}.
 No other elements would be taken into account. The argument is merged with option \code{teal.ggplot2_args} and
 with default module arguments (hard coded in the module body)
 
-For more details, see the help vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
+For more details, see the vignette: \code{vignette("custom-ggplot2-arguments", package = "teal.devel")}.}
 }
 \description{
 This teal module produces a grid style Line Plot for data with


### PR DESCRIPTION
closes #366 

Two modules have wrong docs for ggplot2_args, have full description where as should have limited plot arguments.
line plot and ipp plot modules.

tm_* has to have the same argument description as the function template (top of the file).