### PR TITLE
[hotfix to pre-release] [skip vbump] 382 add extra defaults for numeric stats in tm_t_summary and tm_t_summary_by

### DIFF
--- a/R/tm_t_summary.R
+++ b/R/tm_t_summary.R
@@ -348,7 +348,7 @@ ui_summary <- function(id, ...) {
               "25% and 75%-ile" = "quantiles",
               "Min - Max" = "range"
             ),
-            selected = a$numeric_stats
+            selected = c("n", "mean_sd", "median", "range")
           ),
           radioButtons(
             ns("denominator"),

--- a/R/tm_t_summary_by.R
+++ b/R/tm_t_summary_by.R
@@ -517,7 +517,7 @@ ui_summary_by <- function(id, ...) {
               "25% and 75%-ile" = "quantiles",
               "Min - Max" = "range"
             ),
-            selected = a$numeric_stats
+            selected = c("n", "mean_sd", "median", "range")
           ),
           if (a$dataname == a$parentname) {
             shinyjs::hidden(


### PR DESCRIPTION

See https://github.com/insightsengineering/teal.modules.clinical/pull/383

hotfix on pre-release