### PR TITLE
increase indent teal outputs

### DIFF
--- a/R/tm_t_abnormality.R
+++ b/R/tm_t_abnormality.R
@@ -180,6 +180,7 @@ template_abnormality <- function(parentname,
         var = grade,
         abnormal = abnormal,
         variables = list(id = id_var, baseline = baseline_var),
+        .indent_mods = 4L,
         exclude_base_abn = exclude_base_abn
       ) %>%
         append_varlabels(dataname, grade, indent = indent_space),

--- a/R/tm_t_abnormality_by_worst_grade.R
+++ b/R/tm_t_abnormality_by_worst_grade.R
@@ -176,7 +176,8 @@ template_abnormality_by_worst_grade <- function(parentname, # nolint
         ) %>%
         count_abnormal_by_worst_grade(
           var = "GRADE_ANL",
-          variables = list(id = id_var, param = paramcd, grade_dir = "GRADE_DIR")
+          variables = list(id = id_var, param = paramcd, grade_dir = "GRADE_DIR"),
+          .indent_mods = 4L
         ) %>%
         rtables::append_topleft("    Highest Grade"),
       env = list(

--- a/R/tm_t_shift_by_grade.R
+++ b/R/tm_t_shift_by_grade.R
@@ -424,7 +424,8 @@ template_shift_by_grade <- function(parentname,
       expr = count_occurrences(
         vars = count_var,
         denom = "n",
-        drop = TRUE
+        drop = TRUE,
+        .indent_mods = 4L
       ) %>%
         append_varlabels(dataname, count_var, indent = indent),
       env = list(

--- a/tests/testthat/test-tm_t_abnormality.R
+++ b/tests/testthat/test-tm_t_abnormality.R
@@ -54,6 +54,7 @@ testthat::test_that("template_abnormality generates correct expressions with def
           var = "ANRIND",
           abnormal = list(low = c("LOW", "LOW LOW"), high = c("HIGH", "HIGH HIGH")),
           variables = list(id = "USUBJID", baseline = "BNRIND"),
+          .indent_mods = 4L,
           exclude_base_abn = FALSE
         ) %>%
         append_varlabels(adlb, "ANRIND", indent = 2L)
@@ -126,6 +127,7 @@ testthat::test_that("template_abnormality generates correct expressions with cus
           var = "MYANRIND",
           abnormal = list(Low = "LOW", Medium = "MEDIUM"),
           variables = list(id = "USUBJID", baseline = "MYBASELINE"),
+          .indent_mods = 4L,
           exclude_base_abn = TRUE
         ) %>%
         append_varlabels(adlb, "MYANRIND", indent = 2L)
@@ -196,6 +198,7 @@ testthat::test_that("template_abnormality generates correct expressions with cus
           var = "ANRIND",
           abnormal = list(low = c("LOW", "LOW LOW"), high = c("HIGH", "HIGH HIGH")),
           variables = list(id = "USUBJID", baseline = "BNRIND"),
+          .indent_mods = 4L,
           exclude_base_abn = FALSE
         ) %>%
         append_varlabels(adlb, "ANRIND", indent = 2L)

--- a/tests/testthat/test-tm_t_abnormality_by_worst_grade.R
+++ b/tests/testthat/test-tm_t_abnormality_by_worst_grade.R
@@ -71,7 +71,8 @@ testthat::test_that("template_abnormality_by_worst_grade generates correct expre
             id = "USUBJID",
             param = "PARAMCD",
             grade_dir = "GRADE_DIR"
-          )
+          ),
+          .indent_mods = 4L
         ) %>%
         rtables::append_topleft("    Highest Grade")
     ),
@@ -155,7 +156,8 @@ testthat::test_that("template_abnormality_by_worst_grade generates correct expre
             id = "USUBJID",
             param = "myPARAMCD",
             grade_dir = "GRADE_DIR"
-          )
+          ),
+          .indent_mods = 4L
         ) %>%
         rtables::append_topleft("    Highest Grade")
     ),

--- a/tests/testthat/test-tm_t_shift_by_grade.R
+++ b/tests/testthat/test-tm_t_shift_by_grade.R
@@ -93,7 +93,7 @@ testthat::test_that("template_shift_by_grade generates correct expressions with 
           split_label = formatters::var_labels(anl, fill = FALSE)[["ATOXGR_GP"]]
         ) %>%
         summarize_num_patients(var = "USUBJID", .stats = c("unique_count")) %>%
-        count_occurrences(vars = "BTOXGR_GP", denom = "n", drop = TRUE) %>%
+        count_occurrences(vars = "BTOXGR_GP", denom = "n", drop = TRUE, .indent_mods = 4L) %>%
         append_varlabels(anl, "BTOXGR_GP", indent = 3L)
     ),
     table = quote({
@@ -202,7 +202,7 @@ testthat::test_that("template_shift_by_grade generates correct expressions with 
           split_label = formatters::var_labels(anl, fill = FALSE)[["ATOXGR_GP"]]
         ) %>%
         summarize_num_patients(var = "MYUSUBJID", .stats = c("unique_count")) %>%
-        count_occurrences(vars = "BTOXGR_GP", denom = "n", drop = TRUE) %>%
+        count_occurrences(vars = "BTOXGR_GP", denom = "n", drop = TRUE, .indent_mods = 4L) %>%
         append_varlabels(anl, "BTOXGR_GP", indent = 3L)
     ),
     table = quote({


### PR DESCRIPTION
# Pull Request

Updated tm_t_shift_by_grade, tm_t_abnormality and tm_t_abnormality_by_worst_grade with indents. Indents should be reflected in LBT15, LBT14, and LBT07. 
Refer to https://code.roche.com/nest/docs/tlg-catalog/devel/-/issues/124 

closes #508
