### PR TITLE
Fix `tm_t_tte`, `tm_t_coxreg` footnotes

### DIFF
--- a/R/tm_t_coxreg.R
+++ b/R/tm_t_coxreg.R
@@ -129,8 +129,11 @@ template_coxreg_u <- function(dataname,
     teal.widgets::resolve_basic_table_args(
       user_table = basic_table_args,
       module_table = teal.widgets::basic_table_args(
-        title = paste0("Multi-Variable Cox Regression for ", paramcd),
-        main_footer = "p-value method for Coxph (Hazard Ratio), Ties for Coxph (Hazard Ratio)"
+        title = paste("Multi-Variable Cox Regression for", paramcd),
+        main_footer = c(
+          paste("p-value method for Coxph (Hazard Ratio):", control$pval_method),
+          paste("Ties for Coxph (Hazard Ratio):", control$ties)
+        )
       )
     )
   )
@@ -310,12 +313,14 @@ template_coxreg_m <- function(dataname,
     teal.widgets::resolve_basic_table_args(
       user_table = basic_table_args,
       module_table = teal.widgets::basic_table_args(
-        title = paste0("Cox Regression for ", paramcd),
-        main_footer = "p-value method for Coxph (Hazard Ratio), Ties for Coxph (Hazard Ratio)"
+        title = paste("Cox Regression for", paramcd),
+        main_footer = c(
+          paste("p-value method for Coxph (Hazard Ratio):", control$pval_method),
+          paste("Ties for Coxph (Hazard Ratio):", control$ties)
+        )
       )
     )
   )
-
 
   layout_list <- add_expr(
     layout_list,

--- a/R/tm_t_tte.R
+++ b/R/tm_t_tte.R
@@ -150,9 +150,10 @@ template_tte <- function(dataname = "ANL",
       user_table = basic_table_args,
       module_table = teal.widgets::basic_table_args(
         title = paste("Time-To-Event Table for", paramcd),
-        main_footer = paste0(
-          "p-value method for Coxph (Hazard Ratio), Ties for Coxph (Hazard Ratio), ",
-          "Confidence Level Type for Survfit"
+        main_footer = c(
+          paste("p-value method for Coxph (Hazard Ratio):", control$coxph$pval_method),
+          paste("Ties for Coxph (Hazard Ratio):", control$coxph$ties),
+          paste("Confidence Level Type for Survfit:", control$surv_time$conf_type)
         )
       )
     )

--- a/tests/testthat/test-tm_t_coxreg.R
+++ b/tests/testthat/test-tm_t_coxreg.R
@@ -44,7 +44,10 @@ testthat::test_that("template_coxreg generates correct univariate cox regression
     layout = quote(
       lyt <- rtables::basic_table(
         title = "Multi-Variable Cox Regression for OS",
-        main_footer = "p-value method for Coxph (Hazard Ratio), Ties for Coxph (Hazard Ratio)"
+        main_footer = c(
+          "p-value method for Coxph (Hazard Ratio): wald",
+          "Ties for Coxph (Hazard Ratio): efron"
+        )
       ) %>%
         rtables::split_rows_by("effect") %>%
         rtables::append_topleft("OS") %>%
@@ -104,7 +107,10 @@ testthat::test_that("template_coxreg generates correct univariate cox regression
     layout = quote(
       lyt <- rtables::basic_table(
         title = "Multi-Variable Cox Regression for OS",
-        main_footer = "p-value method for Coxph (Hazard Ratio), Ties for Coxph (Hazard Ratio)"
+        main_footer = c(
+          "p-value method for Coxph (Hazard Ratio): wald",
+          "Ties for Coxph (Hazard Ratio): efron"
+        )
       ) %>%
         rtables::split_rows_by("effect") %>%
         rtables::append_topleft("OS") %>%
@@ -155,7 +161,10 @@ testthat::test_that("template_coxreg generates correct multivariate cox regressi
     layout = quote(
       lyt <- rtables::basic_table(
         title = "Cox Regression for OS",
-        main_footer = "p-value method for Coxph (Hazard Ratio), Ties for Coxph (Hazard Ratio)"
+        main_footer = c(
+          "p-value method for Coxph (Hazard Ratio): wald",
+          "Ties for Coxph (Hazard Ratio): exact"
+        )
       ) %>%
         rtables::append_topleft("OS") %>%
         rtables::split_rows_by("term", child_labels = "hidden") %>%

--- a/tests/testthat/test-tm_t_tte.R
+++ b/tests/testthat/test-tm_t_tte.R
@@ -45,8 +45,11 @@ testthat::test_that("template_tte produces healthy standard output", {
     layout = quote(
       lyt <- rtables::basic_table(
         title = "Time-To-Event Table for OS",
-        main_footer =
-          "p-value method for Coxph (Hazard Ratio), Ties for Coxph (Hazard Ratio), Confidence Level Type for Survfit"
+        main_footer = c(
+          "p-value method for Coxph (Hazard Ratio): log-rank",
+          "Ties for Coxph (Hazard Ratio): efron",
+          "Confidence Level Type for Survfit: plain"
+        )
       ) %>%
         rtables::split_cols_by(var = "ARM") %>%
         rtables::add_colcounts() %>%
@@ -211,8 +214,11 @@ testthat::test_that("template_tte produces correct data expression when comparin
     layout = quote(
       lyt <- rtables::basic_table(
         title = "Time-To-Event Table for OS",
-        main_footer =
-          "p-value method for Coxph (Hazard Ratio), Ties for Coxph (Hazard Ratio), Confidence Level Type for Survfit"
+        main_footer = c(
+          "p-value method for Coxph (Hazard Ratio): log-rank",
+          "Ties for Coxph (Hazard Ratio): efron",
+          "Confidence Level Type for Survfit: plain"
+        )
       ) %>%
         split_cols_by_groups(var = "ARM", groups_list = groups, ref_group = names(groups)[1]) %>%
         rtables::add_colcounts() %>%
@@ -326,8 +332,11 @@ testthat::test_that("template_tte produces correct data expression when comparin
     layout = quote(
       lyt <- rtables::basic_table(
         title = "Time-To-Event Table for OS",
-        main_footer =
-          "p-value method for Coxph (Hazard Ratio), Ties for Coxph (Hazard Ratio), Confidence Level Type for Survfit"
+        main_footer = c(
+          "p-value method for Coxph (Hazard Ratio): log-rank",
+          "Ties for Coxph (Hazard Ratio): efron",
+          "Confidence Level Type for Survfit: plain"
+        )
       ) %>%
         rtables::split_cols_by(var = "ARM", ref_group = "") %>%
         rtables::add_colcounts() %>%


### PR DESCRIPTION
Footnotes for these modules did not include selected values, only the field names.

Original issue: #587 
Original PR: #615 

Closes #623 