### PR TITLE
Update tm_g_barchart_simple.R

### DIFF
--- a/R/tm_g_barchart_simple.R
+++ b/R/tm_g_barchart_simple.R
@@ -375,8 +375,7 @@ srv_g_barchart_simple <- function(id,
                 dplyr::select(.(as.vector(groupby_vars)), dplyr::starts_with("n_"))
             )
           )
-        ),
-        name = "add_label_n_group_by_call"
+        )
       )
 
       # dplyr::select loses labels


### PR DESCRIPTION
# Pull Request

This one line 
```
name = "add_label_n_group_by_call"
``` 
cause the module to crash:
```
example(tm_g_barchart_simple, package = 'teal.modules.clinical')
shinyApp(app$ui, app$server)
Error in teal.code::eval_code: unused argument (name = "add_label_n_group_by_call")
```

Removing it helps, but have a look to be sure.

P.S. it is PR number 666 \m/
