### PR TITLE
consistent reactives naming

### DIFF
--- a/R/tm_a_mmrm.R
+++ b/R/tm_a_mmrm.R
@@ -880,9 +880,9 @@ srv_mmrm <- function(id,
     )
 
     anl_q <- reactive({
-      q1 <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      q2 <- teal.code::eval_code(q1, as.expression(anl_inputs()$expr))
-      teal.code::eval_code(q2, as.expression(adsl_merge_inputs()$expr))
+      qenv <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
+      qenv2 <- teal.code::eval_code(qenv, as.expression(anl_inputs()$expr))
+      teal.code::eval_code(qenv2, as.expression(adsl_merge_inputs()$expr))
     })
 
     # Initially hide the output title because there is no output yet.
@@ -1203,7 +1203,7 @@ srv_mmrm <- function(id,
     # Connector:
     # Fit the MMRM, once the user clicks on the start button.
     mmrm_fit <- shiny::eventReactive(input$button_start, {
-      q1 <- anl_q()
+      qenv <- anl_q()
       anl_m_inputs <- anl_inputs()
 
       my_calls <- template_fit_mmrm(
@@ -1223,7 +1223,7 @@ srv_mmrm <- function(id,
         optimizer = input$optimizer,
         parallel = input$parallel
       )
-      teal.code::eval_code(q1, as.expression(my_calls))
+      teal.code::eval_code(qenv, as.expression(my_calls))
     })
 
     output$mmrm_title <- shiny::renderText({
@@ -1271,13 +1271,13 @@ srv_mmrm <- function(id,
         return(NULL)
       }
       # Get the fit stack while evaluating the fit code at the same time.
-      q1 <- mmrm_fit()
-      fit <- q1[["fit"]]
+      qenv <- mmrm_fit()
+      fit <- qenv[["fit"]]
 
       anl_m_inputs <- anl_inputs()
 
-      ANL <- q1[["ANL"]] # nolint
-      ANL_ADSL <- q1[["ANL_ADSL"]] # nolint
+      ANL <- qenv[["ANL"]] # nolint
+      ANL_ADSL <- qenv[["ANL_ADSL"]] # nolint
       paramcd <- unique(ANL[[unlist(paramcd$filter)["vars_selected"]]])
 
       basic_table_args$subtitles <- paste0(
@@ -1304,7 +1304,7 @@ srv_mmrm <- function(id,
         basic_table_args = basic_table_args
       )
 
-      teal.code::eval_code(q1, as.expression(mmrm_table))
+      teal.code::eval_code(qenv, as.expression(mmrm_table))
     })
 
     # Endpoint:
@@ -1324,8 +1324,8 @@ srv_mmrm <- function(id,
         return(NULL)
       }
 
-      q1 <- mmrm_fit()
-      fit <- q1[["fit"]]
+      qenv <- mmrm_fit()
+      fit <- qenv[["fit"]]
 
       ggplot2_args[["lsmeans"]] <- teal.widgets::ggplot2_args(
         labs <- list(
@@ -1374,7 +1374,7 @@ srv_mmrm <- function(id,
         diagnostic_plot = diagnostic_args,
         ggplot2_args = ggplot2_args
       )
-      teal.code::eval_code(q1, as.expression(mmrm_plot_expr))
+      teal.code::eval_code(qenv, as.expression(mmrm_plot_expr))
     })
 
     all_q <- shiny::reactive({

--- a/R/tm_g_barchart_simple.R
+++ b/R/tm_g_barchart_simple.R
@@ -336,7 +336,7 @@ srv_g_barchart_simple <- function(id,
         shiny::need(anl_inputs()$columns_source$x, "Please select an x-variable")
       })
       qenv <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      qenvv <- teal.code::eval_code(qenv, as.expression(anl_inputs()$expr))
+      qenv <- teal.code::eval_code(qenv, as.expression(anl_inputs()$expr))
       qenv
     })
 

--- a/R/tm_g_barchart_simple.R
+++ b/R/tm_g_barchart_simple.R
@@ -325,24 +325,24 @@ srv_g_barchart_simple <- function(id,
   checkmate::assert_class(data, "tdata")
 
   shiny::moduleServer(id, function(input, output, session) {
-    merge_inputs <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(x = x, fill = fill, x_facet = x_facet, y_facet = y_facet)
     )
 
-    merged_data_q <- shiny::reactive({
+    anl_q <- shiny::reactive({
       shiny::validate({
-        shiny::need(merge_inputs()$columns_source$x, "Please select an x-variable")
+        shiny::need(anl_inputs()$columns_source$x, "Please select an x-variable")
       })
       quo <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      quo <- teal.code::eval_code(quo, as.expression(merge_inputs()$expr))
+      quo <- teal.code::eval_code(quo, as.expression(anl_inputs()$expr))
       quo
     })
 
     count_q <- shiny::reactive({
-      req(merged_data_q())
-      quo <- merged_data_q()
+      req(anl_q())
+      quo <- anl_q()
       teal::validate_has_data(quo[["ANL"]], 2)
       groupby_vars <- r_groupby_vars()
 
@@ -382,14 +382,14 @@ srv_g_barchart_simple <- function(id,
       teal.code::eval_code(
         quo3,
         teal.transform::get_anl_relabel_call(
-          columns_source = merge_inputs()$columns_source,
+          columns_source = anl_inputs()$columns_source,
           datasets = data,
           anl_name = "counts"
         )
       )
     })
 
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       req(count_q())
       groupby_vars <- as.list(r_groupby_vars()) # so $ access works below
 
@@ -441,19 +441,19 @@ srv_g_barchart_simple <- function(id,
       teal.code::eval_code(quo3, code = quote(print(plot)))
     })
 
-    plot_r <- shiny::reactive(output_q()[["plot"]])
+    plot_r <- shiny::reactive(all_q()[["plot"]])
 
-    output$table <- shiny::renderTable(output_q()[["counts"]])
+    output$table <- shiny::renderTable(all_q()[["counts"]])
 
     # reactive vars
     # NULL: not present in UI, vs character(0): no selection
 
     # returns named vector of non-NULL variables to group by
     r_groupby_vars <- function() {
-      x_name <- if (is.null(x)) NULL else as.vector(merge_inputs()$columns_source$x)
-      fill_name <- if (is.null(fill)) NULL else as.vector(merge_inputs()$columns_source$fill)
-      x_facet_name <- if (is.null(x_facet)) NULL else as.vector(merge_inputs()$columns_source$x_facet)
-      y_facet_name <- if (is.null(y_facet)) NULL else as.vector(merge_inputs()$columns_source$y_facet)
+      x_name <- if (is.null(x)) NULL else as.vector(anl_inputs()$columns_source$x)
+      fill_name <- if (is.null(fill)) NULL else as.vector(anl_inputs()$columns_source$fill)
+      x_facet_name <- if (is.null(x_facet)) NULL else as.vector(anl_inputs()$columns_source$x_facet)
+      y_facet_name <- if (is.null(y_facet)) NULL else as.vector(anl_inputs()$columns_source$y_facet)
 
       # set to NULL when empty character
       if (identical(x_name, character(0))) x_name <- NULL
@@ -485,14 +485,14 @@ srv_g_barchart_simple <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = "Bar Chart"
     )
 
@@ -511,7 +511,7 @@ srv_g_barchart_simple <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_g_forest_rsp.R
+++ b/R/tm_g_forest_rsp.R
@@ -729,7 +729,7 @@ srv_g_forest_rsp <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"), dd = "")
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_g_forest_rsp.R
+++ b/R/tm_g_forest_rsp.R
@@ -511,8 +511,8 @@ srv_g_forest_rsp <- function(id,
 
     anl_q <- reactive({
       q <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      q1 <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
-      teal.code::eval_code(q1, as.expression(adsl_inputs()$expr))
+      qenv <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
+      teal.code::eval_code(qenv, as.expression(adsl_inputs()$expr))
     })
 
     shiny::observeEvent(
@@ -565,10 +565,10 @@ srv_g_forest_rsp <- function(id,
     # Prepare the analysis environment (filter data, check data, populate envir).
     validate_checks <- shiny::reactive({
       req(anl_q())
-      q1 <- anl_q()
-      adsl_filtered <- q1[[parentname]]
-      anl_filtered <- q1[[dataname]]
-      anl <- q1[["ANL"]]
+      qenv <- anl_q()
+      adsl_filtered <- qenv[[parentname]]
+      anl_filtered <- qenv[[dataname]]
+      anl <- qenv[["ANL"]]
 
       anl_m <- anl_inputs()
       input_arm_var <- as.vector(anl_m$columns_source$arm_var)
@@ -592,7 +592,7 @@ srv_g_forest_rsp <- function(id,
 
       do.call(what = "validate_standard_inputs", validate_args)
 
-      teal::validate_one_row_per_id(q1[["ANL"]], key = c("USUBJID", "STUDYID", input_paramcd))
+      teal::validate_one_row_per_id(qenv[["ANL"]], key = c("USUBJID", "STUDYID", input_paramcd))
 
       if (length(input_subgroup_var) > 0) {
         shiny::validate(
@@ -658,14 +658,14 @@ srv_g_forest_rsp <- function(id,
         )
       )
 
-      validate_has_data(q1[["ANL"]], min_nrow = 1)
+      validate_has_data(qenv[["ANL"]], min_nrow = 1)
       NULL
     })
 
     # The R-code corresponding to the analysis.
     all_q <- shiny::reactive({
       validate_checks()
-      q1 <- anl_q()
+      qenv <- anl_q()
       anl_m <- anl_inputs()
 
       strata_var <- as.vector(anl_m$columns_source$strata_var)
@@ -689,7 +689,7 @@ srv_g_forest_rsp <- function(id,
         ggplot2_args = ggplot2_args
       )
 
-      teal.code::eval_code(q1, as.expression(my_calls))
+      teal.code::eval_code(qenv, as.expression(my_calls))
     })
 
     plot_r <- reactive(all_q()[["p"]])

--- a/R/tm_g_forest_rsp.R
+++ b/R/tm_g_forest_rsp.R
@@ -489,36 +489,30 @@ srv_g_forest_rsp <- function(id,
       module = "tm_t_tte"
     )
 
-    anl_selectors <- teal.transform::data_extract_multiple_srv(
-      list(
+    anl_inputs <- teal.transform::merge_expression_module(
+      datasets = data,
+      data_extract = list(
         arm_var = arm_var,
         subgroup_var = subgroup_var,
         strata_var = strata_var,
         paramcd = paramcd,
         aval_var = aval_var
       ),
-      datasets = data,
-      join_keys = get_join_keys(data)
-    )
-
-    anl_merged <- teal.transform::merge_expression_srv(
-      selector_list = anl_selectors,
-      datasets = data,
       merge_function = "dplyr::inner_join",
       join_keys = get_join_keys(data)
     )
 
-    adsl_merged <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = list(arm_var = arm_var, subgroup_var = subgroup_var, strata_var = strata_var),
       join_keys = get_join_keys(data),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       q <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      q1 <- teal.code::eval_code(q, as.expression(anl_merged()$expr))
-      teal.code::eval_code(q1, as.expression(adsl_merged()$expr))
+      q1 <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
+      teal.code::eval_code(q1, as.expression(adsl_inputs()$expr))
     })
 
     shiny::observeEvent(
@@ -527,10 +521,10 @@ srv_g_forest_rsp <- function(id,
         input[[extract_input("paramcd", paramcd$filter[[1]]$dataname, filter = TRUE)]]
       ),
       handlerExpr = {
-        req(anl_merged_q())
-        anl <- anl_merged_q()[["ANL"]]
-        aval_var <- anl_merged()$columns_source$aval_var
-        paramcd_level <- unlist(anl_merged()$filter_info$paramcd[[1]]$selected)
+        req(anl_q())
+        anl <- anl_q()[["ANL"]]
+        aval_var <- anl_inputs()$columns_source$aval_var
+        paramcd_level <- unlist(anl_inputs()$filter_info$paramcd[[1]]$selected)
         if (length(paramcd_level) == 0) {
           return(NULL)
         }
@@ -570,13 +564,13 @@ srv_g_forest_rsp <- function(id,
 
     # Prepare the analysis environment (filter data, check data, populate envir).
     validate_checks <- shiny::reactive({
-      req(anl_merged_q())
-      q1 <- anl_merged_q()
+      req(anl_q())
+      q1 <- anl_q()
       adsl_filtered <- q1[[parentname]]
       anl_filtered <- q1[[dataname]]
       anl <- q1[["ANL"]]
 
-      anl_m <- anl_merged()
+      anl_m <- anl_inputs()
       input_arm_var <- as.vector(anl_m$columns_source$arm_var)
       input_aval_var <- as.vector(anl_m$columns_source$aval_var)
       input_subgroup_var <- as.vector(anl_m$columns_source$subgroup_var)
@@ -669,10 +663,10 @@ srv_g_forest_rsp <- function(id,
     })
 
     # The R-code corresponding to the analysis.
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
-      q1 <- anl_merged_q()
-      anl_m <- anl_merged()
+      q1 <- anl_q()
+      anl_m <- anl_inputs()
 
       strata_var <- as.vector(anl_m$columns_source$strata_var)
       subgroup_var <- as.vector(anl_m$columns_source$subgroup_var)
@@ -698,7 +692,7 @@ srv_g_forest_rsp <- function(id,
       teal.code::eval_code(q1, as.expression(my_calls))
     })
 
-    plot_r <- reactive(output_q()[["p"]])
+    plot_r <- reactive(all_q()[["p"]])
 
     pws <- teal.widgets::plot_with_settings_srv(
       id = "myplot",
@@ -709,14 +703,14 @@ srv_g_forest_rsp <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -735,7 +729,7 @@ srv_g_forest_rsp <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"), dd = "")
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"), dd = "")
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_g_forest_tte.R
+++ b/R/tm_g_forest_tte.R
@@ -494,7 +494,8 @@ srv_g_forest_tte <- function(id,
       module = "tm_g_forest_tte"
     )
 
-    anl_selectors <- teal.transform::data_extract_multiple_srv(
+    anl_inputs <- teal.transform::merge_expression_module(
+      datasets = data,
       data_extract = list(
         arm_var = arm_var,
         paramcd = paramcd,
@@ -504,37 +505,30 @@ srv_g_forest_tte <- function(id,
         cnsr_var = cnsr_var,
         time_unit_var = time_unit_var
       ),
-      datasets = data,
-      join_keys = get_join_keys(data)
-    )
-
-    anl_merged <- teal.transform::merge_expression_srv(
-      selector_list = anl_selectors,
-      datasets = data,
       join_keys = get_join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(arm_var = arm_var, subgroup_var = subgroup_var, strata_var = strata_var),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       q <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      q1 <- teal.code::eval_code(q, as.expression(anl_merged()$expr))
-      teal.code::eval_code(q1, as.expression(adsl_merged()$expr))
+      q1 <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
+      teal.code::eval_code(q1, as.expression(adsl_inputs()$expr))
     })
 
     validate_checks <- shiny::reactive({
-      q1 <- anl_merged_q()
+      q1 <- anl_q()
       adsl_filtered <- q1[[parentname]]
       anl_filtered <- q1[[dataname]]
       anl <- q1[["ANL"]]
 
-      anl_m <- anl_merged()
+      anl_m <- anl_inputs()
       input_arm_var <- as.vector(anl_m$columns_source$arm_var)
       input_aval_var <- as.vector(anl_m$columns_source$aval_var)
       input_cnsr_var <- as.vector(anl_m$columns_source$cnsr_var)
@@ -600,11 +594,11 @@ srv_g_forest_tte <- function(id,
     })
 
     # The R-code corresponding to the analysis.
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
-      q1 <- anl_merged_q()
-      anl_m <- anl_merged()
+      q1 <- anl_q()
+      anl_m <- anl_inputs()
 
       strata_var <- as.vector(anl_m$columns_source$strata_var)
       subgroup_var <- as.vector(anl_m$columns_source$subgroup_var)
@@ -631,7 +625,7 @@ srv_g_forest_tte <- function(id,
     })
 
     # Outputs to render.
-    plot_r <- shiny::reactive(output_q()[["p"]])
+    plot_r <- shiny::reactive(all_q()[["p"]])
 
     pws <- teal.widgets::plot_with_settings_srv(
       id = "myplot",
@@ -642,14 +636,14 @@ srv_g_forest_tte <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = "R Code for the Current Time-to-Event Forest Plot"
     )
 
@@ -668,7 +662,7 @@ srv_g_forest_tte <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_g_forest_tte.R
+++ b/R/tm_g_forest_tte.R
@@ -518,15 +518,15 @@ srv_g_forest_tte <- function(id,
 
     anl_q <- reactive({
       q <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      q1 <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
-      teal.code::eval_code(q1, as.expression(adsl_inputs()$expr))
+      qenv <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
+      teal.code::eval_code(qenv, as.expression(adsl_inputs()$expr))
     })
 
     validate_checks <- shiny::reactive({
-      q1 <- anl_q()
-      adsl_filtered <- q1[[parentname]]
-      anl_filtered <- q1[[dataname]]
-      anl <- q1[["ANL"]]
+      qenv <- anl_q()
+      adsl_filtered <- qenv[[parentname]]
+      anl_filtered <- qenv[[dataname]]
+      anl <- qenv[["ANL"]]
 
       anl_m <- anl_inputs()
       input_arm_var <- as.vector(anl_m$columns_source$arm_var)
@@ -597,7 +597,7 @@ srv_g_forest_tte <- function(id,
     all_q <- shiny::reactive({
       validate_checks()
 
-      q1 <- anl_q()
+      qenv <- anl_q()
       anl_m <- anl_inputs()
 
       strata_var <- as.vector(anl_m$columns_source$strata_var)
@@ -621,7 +621,7 @@ srv_g_forest_tte <- function(id,
         time_unit_var = as.vector(anl_m$columns_source$time_unit_var),
         ggplot2_args = ggplot2_args
       )
-      teal.code::eval_code(q1, as.expression(my_calls))
+      teal.code::eval_code(qenv, as.expression(my_calls))
     })
 
     # Outputs to render.

--- a/R/tm_g_ipp.R
+++ b/R/tm_g_ipp.R
@@ -474,7 +474,7 @@ srv_g_ipp <- function(id,
   checkmate::assert_class(data, "tdata")
 
   shiny::moduleServer(id, function(input, output, session) {
-    anl_merged <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = list(
         arm_var = arm_var,
@@ -489,26 +489,26 @@ srv_g_ipp <- function(id,
       join_keys = get_join_keys(data)
     )
 
-    adsl_merged <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(arm_var = arm_var, id_var = id_var),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       q <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      q1 <- teal.code::eval_code(q, as.expression(anl_merged()$expr))
-      teal.code::eval_code(q1, as.expression(adsl_merged()$expr))
+      q1 <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
+      teal.code::eval_code(q1, as.expression(adsl_inputs()$expr))
     })
 
     # Prepare the analysis environment (filter data, check data, populate envir).
     validate_checks <- shiny::reactive({
-      q1 <- anl_merged_q()
+      q1 <- anl_q()
       adsl_filtered <- q1[[parentname]]
       anl_filtered <- q1[[dataname]]
 
-      anl_m <- anl_merged()
+      anl_m <- anl_inputs()
       input_arm_var <- unlist(arm_var$filter)["vars_selected"]
       input_aval_var <- as.vector(anl_m$columns_source$aval_var)
       input_avalu_var <- as.vector(anl_m$columns_source$avalu_var)
@@ -549,10 +549,10 @@ srv_g_ipp <- function(id,
     })
 
     # The R-code corresponding to the analysis.
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
-      q1 <- anl_merged_q()
-      anl_m <- anl_merged()
+      q1 <- anl_q()
+      anl_m <- anl_inputs()
 
       ANL <- q1[["ANL"]] # nolint
       teal::validate_has_data(ANL, 2)
@@ -587,7 +587,7 @@ srv_g_ipp <- function(id,
     })
 
     # Outputs to render.
-    plot_r <- shiny::reactive(output_q()[["plot"]])
+    plot_r <- shiny::reactive(all_q()[["plot"]])
 
     # Insert the plot into a plot with settings module from teal.widgets
     pws <- teal.widgets::plot_with_settings_srv(
@@ -599,14 +599,14 @@ srv_g_ipp <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -625,7 +625,7 @@ srv_g_ipp <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_g_ipp.R
+++ b/R/tm_g_ipp.R
@@ -498,15 +498,15 @@ srv_g_ipp <- function(id,
 
     anl_q <- reactive({
       q <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      q1 <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
-      teal.code::eval_code(q1, as.expression(adsl_inputs()$expr))
+      qenv <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
+      teal.code::eval_code(qenv, as.expression(adsl_inputs()$expr))
     })
 
     # Prepare the analysis environment (filter data, check data, populate envir).
     validate_checks <- shiny::reactive({
-      q1 <- anl_q()
-      adsl_filtered <- q1[[parentname]]
-      anl_filtered <- q1[[dataname]]
+      qenv <- anl_q()
+      adsl_filtered <- qenv[[parentname]]
+      anl_filtered <- qenv[[dataname]]
 
       anl_m <- anl_inputs()
       input_arm_var <- unlist(arm_var$filter)["vars_selected"]
@@ -551,10 +551,10 @@ srv_g_ipp <- function(id,
     # The R-code corresponding to the analysis.
     all_q <- shiny::reactive({
       validate_checks()
-      q1 <- anl_q()
+      qenv <- anl_q()
       anl_m <- anl_inputs()
 
-      ANL <- q1[["ANL"]] # nolint
+      ANL <- qenv[["ANL"]] # nolint
       teal::validate_has_data(ANL, 2)
 
       arm_var <- unlist(arm_var$filter)["vars_selected"]
@@ -583,7 +583,7 @@ srv_g_ipp <- function(id,
         ggplot2_args = ggplot2_args,
         add_avalu = input$add_avalu
       )
-      teal.code::eval_code(q1, as.expression(my_calls))
+      teal.code::eval_code(qenv, as.expression(my_calls))
     })
 
     # Outputs to render.

--- a/R/tm_g_km.R
+++ b/R/tm_g_km.R
@@ -668,9 +668,9 @@ srv_g_km <- function(id,
     })
 
     validate_checks <- shiny::reactive({
-      q1 <- anl_q()
-      adsl_filtered <- q1[[parentname]]
-      anl_filtered <- q1[[dataname]]
+      qenv <- anl_q()
+      adsl_filtered <- qenv[[parentname]]
+      anl_filtered <- qenv[[dataname]]
 
       anl_m <- anl_inputs()
       input_arm_var <- as.vector(anl_m$columns_source$arm_var)
@@ -734,10 +734,10 @@ srv_g_km <- function(id,
     all_q <- shiny::reactive({
       validate_checks()
 
-      q1 <- anl_q()
+      qenv <- anl_q()
       anl_m <- anl_inputs()
 
-      anl <- q1[["ANL"]] # nolint
+      anl <- qenv[["ANL"]] # nolint
       teal::validate_has_data(anl, 2)
 
       input_xticks <- gsub(";", ",", trimws(input$xticks)) %>%
@@ -777,7 +777,7 @@ srv_g_km <- function(id,
         ci_ribbon = input$show_ci_ribbon,
         title = title
       )
-      teal.code::eval_code(q1, as.expression(my_calls))
+      teal.code::eval_code(qenv, as.expression(my_calls))
     })
 
     plot_r <- shiny::reactive(all_q()[["plot"]])

--- a/R/tm_g_lineplot.R
+++ b/R/tm_g_lineplot.R
@@ -518,19 +518,19 @@ srv_g_lineplot <- function(id,
   checkmate::assert_class(data, "tdata")
 
   shiny::moduleServer(id, function(input, output, session) {
-    anl_merged_input <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = list(x = x, y = y, strata = strata, paramcd = paramcd, y_unit = y_unit, param = param),
       join_keys = get_join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr))
     })
 
-    merged <- list(anl_input_r = anl_merged_input, anl_q_r = anl_merged_q)
+    merged <- list(anl_input_r = anl_inputs, anl_q = anl_q)
 
     validate_checks <- shiny::reactive({
       adsl_filtered <- data[[parentname]]()
@@ -576,9 +576,9 @@ srv_g_lineplot <- function(id,
       NULL
     })
 
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]] # nolint
       teal::validate_has_data(ANL, 2)
 
       whiskers_selected <- ifelse(input$whiskers == "Lower", 1, ifelse(input$whiskers == "Upper", 2, 1:2))
@@ -604,10 +604,10 @@ srv_g_lineplot <- function(id,
         table_font_size = input$table_font_size,
         ggplot2_args = ggplot2_args
       )
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
-    plot_r <- shiny::reactive(output_q()[["plot"]])
+    plot_r <- shiny::reactive(all_q()[["plot"]])
 
     # Insert the plot into a plot with settings module from teal.widgets
     pws <- teal.widgets::plot_with_settings_srv(
@@ -619,14 +619,14 @@ srv_g_lineplot <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -645,7 +645,7 @@ srv_g_lineplot <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_g_lineplot.R
+++ b/R/tm_g_lineplot.R
@@ -533,8 +533,8 @@ srv_g_lineplot <- function(id,
     merged <- list(anl_input_r = anl_inputs, anl_q = anl_q)
 
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_strata <- names(merged$anl_input_r()$columns_source$strata)
       input_x_var <- names(merged$anl_input_r()$columns_source$x)

--- a/R/tm_g_pp_adverse_events.R
+++ b/R/tm_g_pp_adverse_events.R
@@ -476,7 +476,7 @@ srv_g_adverse_events <- function(id,
       )
     )
 
-    outputs_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       shiny::validate(shiny::need(patient_id(), "Please select a patient."))
       anl_m <- anl_inputs()
       qenv <- anl_q()
@@ -539,11 +539,11 @@ srv_g_adverse_events <- function(id,
       teal.code::eval_code(qenv2, as.expression(calls))
     })
     output$table <- DT::renderDataTable(
-      expr = outputs_q()[["table"]],
+      expr = all_q()[["table"]],
       options = list(pageLength = input$table_rows)
     )
 
-    plot_r <- shiny::reactive(outputs_q()[["plot"]])
+    plot_r <- shiny::reactive(all_q()[["plot"]])
 
     pws <- teal.widgets::plot_with_settings_srv(
       id = "chart",
@@ -554,14 +554,14 @@ srv_g_adverse_events <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(outputs_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(outputs_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(outputs_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -580,7 +580,7 @@ srv_g_adverse_events <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(outputs_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_g_pp_adverse_events.R
+++ b/R/tm_g_pp_adverse_events.R
@@ -479,8 +479,8 @@ srv_g_adverse_events <- function(id,
     outputs_q <- shiny::reactive({
       shiny::validate(shiny::need(patient_id(), "Please select a patient."))
       anl_m <- anl_inputs()
-      q1 <- anl_q()
-      ANL <- q1[["ANL"]] # nolint
+      qenv <- anl_q()
+      ANL <- qenv[["ANL"]] # nolint
 
       teal::validate_has_data(ANL[ANL[[patient_col]] == input$patient_id, ], min_nrow = 1)
 
@@ -511,8 +511,8 @@ srv_g_adverse_events <- function(id,
         )
       )
 
-      q2 <- teal.code::eval_code(
-        q1,
+      qenv2 <- teal.code::eval_code(
+        qenv,
         substitute(
           expr = ANL <- ANL[ANL[[patient_col]] == patient_id, ], # nolint
           env = list(
@@ -536,7 +536,7 @@ srv_g_adverse_events <- function(id,
         ggplot2_args = ggplot2_args
       )
 
-      teal.code::eval_code(q2, as.expression(calls))
+      teal.code::eval_code(qenv2, as.expression(calls))
     })
     output$table <- DT::renderDataTable(
       expr = outputs_q()[["table"]],

--- a/R/tm_g_pp_adverse_events.R
+++ b/R/tm_g_pp_adverse_events.R
@@ -453,7 +453,7 @@ srv_g_adverse_events <- function(id,
     )
 
     # Adverse events tab ----
-    anl_merged <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = Filter(
         Negate(is.null),
@@ -470,16 +470,16 @@ srv_g_adverse_events <- function(id,
       join_keys = get_join_keys(data)
     )
 
-    anl_merged_q <- reactive(
+    anl_q <- reactive(
       teal.code::eval_code(
-        teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)), as.expression(anl_merged()$expr)
+        teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)), as.expression(anl_inputs()$expr)
       )
     )
 
     outputs_q <- shiny::reactive({
       shiny::validate(shiny::need(patient_id(), "Please select a patient."))
-      anl_m <- anl_merged()
-      q1 <- anl_merged_q()
+      anl_m <- anl_inputs()
+      q1 <- anl_q()
       ANL <- q1[["ANL"]] # nolint
 
       teal::validate_has_data(ANL[ANL[[patient_col]] == input$patient_id, ], min_nrow = 1)

--- a/R/tm_g_pp_vitals.R
+++ b/R/tm_g_pp_vitals.R
@@ -406,19 +406,19 @@ srv_g_vitals <- function(id,
     )
 
     # Vitals tab ----
-    anl_merged_input <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(paramcd = paramcd, xaxis = xaxis, aval = aval),
       merge_function = "dplyr::left_join"
     )
 
-    anl_q_r <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr))
     })
 
-    merged <- list(anl_input_r = anl_merged_input, anl_q_r = anl_q_r)
+    merged <- list(anl_input_r = anl_inputs, anl_q = anl_q)
 
     output$paramcd_levels <- shiny::renderUI({
       paramcd_var <- input[[extract_input("paramcd", dataname)]]
@@ -426,7 +426,7 @@ srv_g_vitals <- function(id,
       shiny::req(paramcd_var)
       shiny::req(input$patient_id)
 
-      vitals_dat <- merged$anl_q_r()[["ANL"]]
+      vitals_dat <- merged$anl_q()[["ANL"]]
       vitals_dat_sub <- vitals_dat[vitals_dat[[patient_col]] == patient_id(), ]
       paramcd_col <- vitals_dat_sub[[paramcd_var]]
       paramcd_col_levels <- unique(paramcd_col)
@@ -450,9 +450,9 @@ srv_g_vitals <- function(id,
       )
     })
 
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       shiny::validate(shiny::need(patient_id(), "Please select a patient."))
-      teal::validate_has_data(merged$anl_q_r()[["ANL"]], 1)
+      teal::validate_has_data(merged$anl_q()[["ANL"]], 1)
 
       shiny::validate(
         shiny::need(
@@ -472,7 +472,7 @@ srv_g_vitals <- function(id,
           "Please select AVAL variable."
         ),
         shiny::need(
-          nrow(merged$anl_q_r()[["ANL"]][input$patient_id == merged$anl_q_r()[["ANL"]][, patient_col], ]) > 0,
+          nrow(merged$anl_q()[["ANL"]][input$patient_id == merged$anl_q()[["ANL"]][, patient_col], ]) > 0,
           "Selected patient is not in dataset (either due to filtering or missing values). Consider relaxing filters."
         )
       )
@@ -489,7 +489,7 @@ srv_g_vitals <- function(id,
       )
 
       teal.code::eval_code(
-        merged$anl_q_r(),
+        merged$anl_q(),
         substitute(
           expr = {
             ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
@@ -502,7 +502,7 @@ srv_g_vitals <- function(id,
         teal.code::eval_code(as.expression(my_calls))
     })
 
-    plot_r <- shiny::reactive(output_q()[["result_plot"]])
+    plot_r <- shiny::reactive(all_q()[["result_plot"]])
 
     pws <- teal.widgets::plot_with_settings_srv(
       id = "vitals_plot",
@@ -513,14 +513,14 @@ srv_g_vitals <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -539,7 +539,7 @@ srv_g_vitals <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_abnormality.R
+++ b/R/tm_t_abnormality.R
@@ -499,7 +499,6 @@ srv_t_abnormality <- function(id,
   checkmate::assert_class(data, "tdata")
 
   shiny::moduleServer(id, function(input, output, session) {
-
     anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = list(

--- a/R/tm_t_abnormality.R
+++ b/R/tm_t_abnormality.R
@@ -533,8 +533,8 @@ srv_t_abnormality <- function(id,
     )
 
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_arm_var <- names(merged$anl_input_r()$columns_source$arm_var)
       input_id_var <- names(merged$anl_input_r()$columns_source$id_var)

--- a/R/tm_t_abnormality.R
+++ b/R/tm_t_abnormality.R
@@ -499,8 +499,10 @@ srv_t_abnormality <- function(id,
   checkmate::assert_class(data, "tdata")
 
   shiny::moduleServer(id, function(input, output, session) {
-    anl_selectors <- teal.transform::data_extract_multiple_srv(
-      list(
+
+    anl_inputs <- teal.transform::merge_expression_module(
+      datasets = data,
+      data_extract = list(
         arm_var = arm_var,
         id_var = id_var,
         by_vars = by_vars,
@@ -508,32 +510,27 @@ srv_t_abnormality <- function(id,
         baseline_var = baseline_var,
         treatment_flag_var = treatment_flag_var
       ),
-      datasets = data
-    )
-    anl_merged_input <- teal.transform::merge_expression_srv(
-      selector_list = anl_selectors,
-      datasets = data,
       join_keys = get_join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(arm_var = arm_var),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     validate_checks <- shiny::reactive({
@@ -566,12 +563,12 @@ srv_t_abnormality <- function(id,
       )
     })
 
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
       by_vars_names <- merged$anl_input_r()$columns_source$by_vars
       by_vars_labels <- as.character(sapply(by_vars_names, function(name) {
-        attr(merged$anl_q_r()[["ANL"]][[name]], "label")
+        attr(merged$anl_q()[["ANL"]][[name]], "label")
       }))
 
       tbl_title <- ifelse(
@@ -599,11 +596,11 @@ srv_t_abnormality <- function(id,
         tbl_title = tbl_title
       )
 
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -612,15 +609,15 @@ srv_t_abnormality <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -639,7 +636,7 @@ srv_t_abnormality <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_abnormality_by_worst_grade.R
+++ b/R/tm_t_abnormality_by_worst_grade.R
@@ -510,8 +510,8 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint
     )
 
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
       anl <- merged$anl_q()[["ANL"]]
 
       input_arm_var <- names(merged$anl_input_r()$columns_source$arm_var)

--- a/R/tm_t_abnormality_by_worst_grade.R
+++ b/R/tm_t_abnormality_by_worst_grade.R
@@ -479,7 +479,7 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint
   checkmate::assert_class(data, "tdata")
 
   shiny::moduleServer(id, function(input, output, session) {
-    anl_merged_input <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(
@@ -490,29 +490,29 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(arm_var = arm_var),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     validate_checks <- shiny::reactive({
       adsl_filtered <- data[[parentname]]()
       anl_filtered <- data[[dataname]]()
-      anl <- merged$anl_q_r()[["ANL"]]
+      anl <- merged$anl_q()[["ANL"]]
 
       input_arm_var <- names(merged$anl_input_r()$columns_source$arm_var)
       input_id_var <- names(merged$anl_input_r()$columns_source$id_var)
@@ -533,11 +533,11 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint
       if (length(input_paramcd_var) > 0) {
         shiny::validate(
           shiny::need(
-            length(merged$anl_q_r()[["ANL"]][[input_paramcd_var]]) > 0,
+            length(merged$anl_q()[["ANL"]][[input_paramcd_var]]) > 0,
             "Please select at least one Laboratory parameter."
           ),
           shiny::need(
-            is.factor(merged$anl_q_r()[["ANL"]][[input_paramcd_var]]),
+            is.factor(merged$anl_q()[["ANL"]][[input_paramcd_var]]),
             "Parameter variable should be a factor."
           )
         )
@@ -546,16 +546,16 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint
       if (length(input_atoxgr) > 0) {
         shiny::validate(
           shiny::need(
-            all(as.character(unique(merged$anl_q_r()[["ANL"]][[input_atoxgr]])) %in% as.character(c(-4:4))),
+            all(as.character(unique(merged$anl_q()[["ANL"]][[input_atoxgr]])) %in% as.character(c(-4:4))),
             "All grade values should be within -4:4 range."
           ),
-          shiny::need(is.factor(merged$anl_q_r()[["ANL"]][[input_atoxgr]]), "Grade variable should be a factor.")
+          shiny::need(is.factor(merged$anl_q()[["ANL"]][[input_atoxgr]]), "Grade variable should be a factor.")
         )
       }
 
       if (length(input_atoxgr) > 0) {
         shiny::validate(
-          shiny::need(is.factor(merged$anl_q_r()[["ANL"]][[input_atoxgr]]), "Treatment variable should be a factor."),
+          shiny::need(is.factor(merged$anl_q()[["ANL"]][[input_atoxgr]]), "Treatment variable should be a factor."),
         )
       }
 
@@ -573,7 +573,7 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint
       )
     })
 
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
       my_calls <- template_abnormality_by_worst_grade(
@@ -591,11 +591,11 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint
         basic_table_args = basic_table_args
       )
 
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -604,15 +604,15 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -632,7 +632,7 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_ancova.R
+++ b/R/tm_t_ancova.R
@@ -550,7 +550,7 @@ srv_ancova <- function(id,
       module = "tm_ancova"
     )
 
-    anl_merged_input <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = list(
         arm_var = arm_var,
@@ -563,23 +563,23 @@ srv_ancova <- function(id,
       join_keys = get_join_keys(data)
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = list(arm_var = arm_var),
       anl_name = "ANL_ADSL",
       join_keys = get_join_keys(data)
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     # Prepare the analysis environment (filter data, check data, populate envir).
@@ -618,11 +618,11 @@ srv_ancova <- function(id,
       ))
       # check that there is at least one record with no missing data
       shiny::validate(shiny::need(
-        !all(is.na(merged$anl_q_r()[["ANL"]][[input_aval_var]])),
+        !all(is.na(merged$anl_q()[["ANL"]][[input_aval_var]])),
         "ANCOVA table cannot be calculated as all values are missing."
       ))
       # check that for each visit there is at least one record with no missing data
-      all_NA_dataset <- merged$anl_q_r()[["ANL"]] %>% # nolint
+      all_NA_dataset <- merged$anl_q()[["ANL"]] %>% # nolint
         dplyr::group_by(dplyr::across(dplyr::all_of(c(input_avisit, input_arm_var)))) %>%
         dplyr::summarize(all_NA = all(is.na(.data[[input_aval_var]])))
       shiny::validate(shiny::need(
@@ -656,9 +656,9 @@ srv_ancova <- function(id,
     })
 
     # The R-code corresponding to the analysis.
-    output_table <- shiny::reactive({
+    table_q <- shiny::reactive({
       validate_checks()
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]] # nolint
 
       label_paramcd <- get_paramcd_label(ANL, paramcd)
       input_aval <- as.vector(merged$anl_input_r()$columns_source$aval_var)
@@ -684,12 +684,12 @@ srv_ancova <- function(id,
         conf_level = as.numeric(input$conf_level),
         basic_table_args = basic_table_args
       )
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Output to render.
     table_r <- shiny::reactive({
-      output_table()[["result"]]
+      table_q()[["result"]]
     })
 
     teal.widgets::table_with_settings_srv(
@@ -699,15 +699,15 @@ srv_ancova <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_table())),
+      verbatim_content = reactive(teal.code::get_warnings(table_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_table())))
+      disabled = reactive(is.null(teal.code::get_warnings(table_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_table())),
+      verbatim_content = reactive(teal.code::get_code(table_q())),
       title = label
     )
 
@@ -727,7 +727,7 @@ srv_ancova <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_table()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(table_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_ancova.R
+++ b/R/tm_t_ancova.R
@@ -584,8 +584,8 @@ srv_ancova <- function(id,
 
     # Prepare the analysis environment (filter data, check data, populate envir).
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_arm_var <- as.vector(merged$anl_input_r()$columns_source$arm_var)
       input_aval_var <- as.vector(merged$anl_input_r()$columns_source$aval_var)

--- a/R/tm_t_binary_outcome.R
+++ b/R/tm_t_binary_outcome.R
@@ -770,8 +770,8 @@ srv_t_binary_outcome <- function(id,
 
     anl_q <- reactive({
       q <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      q1 <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
-      teal.code::eval_code(q1, as.expression(adsl_inputs()$expr))
+      qenv <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
+      teal.code::eval_code(qenv, as.expression(adsl_inputs()$expr))
     })
 
     shiny::observeEvent(
@@ -815,10 +815,9 @@ srv_t_binary_outcome <- function(id,
     )
 
     validate_check <- shiny::reactive({
-      q1 <- anl_q()
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
-      anl <- q1[["ANL"]]
+      adsl_filtered <- anl_q()[[parentname]]
+      anl_filtered <- anl_q()[[dataname]]
+      anl <- anl_q()[["ANL"]]
 
       anl_m <- anl_inputs()
       input_arm_var <- as.vector(anl_m$columns_source$arm_var)
@@ -912,9 +911,9 @@ srv_t_binary_outcome <- function(id,
     table_q <- shiny::reactive({
       validate_check()
 
-      q1 <- anl_q()
+      qenv <- anl_q()
       anl_m <- anl_inputs()
-      anl <- q1[["ANL"]]
+      anl <- qenv[["ANL"]]
 
       input_aval_var <- as.vector(anl_m$columns_source$aval_var)
       shiny::req(input$responders %in% anl[[input_aval_var]])
@@ -963,7 +962,7 @@ srv_t_binary_outcome <- function(id,
         basic_table_args = basic_table_args
       )
 
-      teal.code::eval_code(q1, as.expression(my_calls))
+      teal.code::eval_code(qenv, as.expression(my_calls))
     })
 
     # Outputs to render.

--- a/R/tm_t_binary_outcome.R
+++ b/R/tm_t_binary_outcome.R
@@ -754,24 +754,24 @@ srv_t_binary_outcome <- function(id,
       on_off = shiny::reactive(input$compare_arms)
     )
 
-    anl_merged <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = list(arm_var = arm_var, paramcd = paramcd, strata_var = strata_var, aval_var = aval_var),
       merge_function = "dplyr::inner_join",
       join_keys = get_join_keys(data)
     )
 
-    adsl_merged <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = list(arm_var = arm_var, strata_var = strata_var),
       join_keys = get_join_keys(data),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       q <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      q1 <- teal.code::eval_code(q, as.expression(anl_merged()$expr))
-      teal.code::eval_code(q1, as.expression(adsl_merged()$expr))
+      q1 <- teal.code::eval_code(q, as.expression(anl_inputs()$expr))
+      teal.code::eval_code(q1, as.expression(adsl_inputs()$expr))
     })
 
     shiny::observeEvent(
@@ -780,8 +780,8 @@ srv_t_binary_outcome <- function(id,
         input[[extract_input("paramcd", paramcd$filter[[1]]$dataname, filter = TRUE)]]
       ),
       handlerExpr = {
-        anl <- anl_merged_q()[["ANL"]]
-        aval_var <- anl_merged()$columns_source$aval_var
+        anl <- anl_q()[["ANL"]]
+        aval_var <- anl_inputs()$columns_source$aval_var
         paramcd <- input[[extract_input("paramcd", paramcd$filter[[1]]$dataname, filter = TRUE)]]
         sel_param <- if (is.list(default_responses) && (!is.null(paramcd))) {
           default_responses[[paramcd]]
@@ -815,12 +815,12 @@ srv_t_binary_outcome <- function(id,
     )
 
     validate_check <- shiny::reactive({
-      q1 <- anl_merged_q()
+      q1 <- anl_q()
       adsl_filtered <- data[[parentname]]()
       anl_filtered <- data[[dataname]]()
       anl <- q1[["ANL"]]
 
-      anl_m <- anl_merged()
+      anl_m <- anl_inputs()
       input_arm_var <- as.vector(anl_m$columns_source$arm_var)
       input_strata_var <- as.vector(anl_m$columns_source$strata_var)
       input_aval_var <- as.vector(anl_m$columns_source$aval_var)
@@ -909,11 +909,11 @@ srv_t_binary_outcome <- function(id,
       NULL
     })
 
-    output_table <- shiny::reactive({
+    table_q <- shiny::reactive({
       validate_check()
 
-      q1 <- anl_merged_q()
-      anl_m <- anl_merged()
+      q1 <- anl_q()
+      anl_m <- anl_inputs()
       anl <- q1[["ANL"]]
 
       input_aval_var <- as.vector(anl_m$columns_source$aval_var)
@@ -967,7 +967,7 @@ srv_t_binary_outcome <- function(id,
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_table()[["result"]])
+    table_r <- shiny::reactive(table_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -976,16 +976,16 @@ srv_t_binary_outcome <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_table())),
+      verbatim_content = reactive(teal.code::get_warnings(table_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_table())))
+      disabled = reactive(is.null(teal.code::get_warnings(table_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
       verbatim_content = reactive({
-        teal.code::get_code(output_table())
+        teal.code::get_code(table_q())
       }),
       title = label
     )
@@ -1005,7 +1005,7 @@ srv_t_binary_outcome <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_table()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(table_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_coxreg.R
+++ b/R/tm_t_coxreg.R
@@ -766,7 +766,7 @@ srv_t_coxreg <- function(id,
       module = "tm_t_coxreg"
     )
 
-    anl_merged_input <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(
@@ -780,14 +780,14 @@ srv_t_coxreg <- function(id,
       merge_function = "dplyr::inner_join"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      anl_q = anl_q
     )
 
     ## render conditional strata levels input UI  ----
@@ -1005,10 +1005,10 @@ srv_t_coxreg <- function(id,
     }
 
     ## generate table call with template and render table ----
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]] # nolint
       paramcd <- as.character(unique(ANL[[unlist(paramcd$filter)["vars_selected"]]]))
       multivariate <- input$type == "Multivariate"
       strata_var <- as.vector(merged$anl_input_r()$columns_source$strata_var)
@@ -1027,7 +1027,7 @@ srv_t_coxreg <- function(id,
           unlist(input$buckets$Comp), merged$anl_input_r(),
           paramcd, multivariate, all_basic_table_args
         )
-        teal.code::eval_code(merged$anl_q_r(), as.expression(expr))
+        teal.code::eval_code(merged$anl_q(), as.expression(expr))
       } else {
         main_title <- paste("Cox Regression for", paramcd)
         subtitle <- ifelse(length(strata_var) == 0, "", paste("Stratified by", paste(strata_var, collapse = " and ")))
@@ -1039,7 +1039,7 @@ srv_t_coxreg <- function(id,
           )
         )
 
-        merged$anl_q_r() %>%
+        merged$anl_q() %>%
           teal.code::eval_code(quote(result <- list())) %>%
           teal.code::eval_code(
             as.expression(unlist(lapply(
@@ -1072,7 +1072,7 @@ srv_t_coxreg <- function(id,
       }
     })
 
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -1081,14 +1081,14 @@ srv_t_coxreg <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = "R Code for the Current (Multi-variable) Cox proportional hazard regression model"
     )
 
@@ -1107,7 +1107,7 @@ srv_t_coxreg <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_coxreg.R
+++ b/R/tm_t_coxreg.R
@@ -818,8 +818,8 @@ srv_t_coxreg <- function(id,
 
     ## Prepare the call evaluation environment ----
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_arm_var <- as.vector(merged$anl_input_r()$columns_source$arm_var)
       input_strata_var <- as.vector(merged$anl_input_r()$columns_source$strata_var)

--- a/R/tm_t_events.R
+++ b/R/tm_t_events.R
@@ -639,36 +639,30 @@ srv_t_events_byterm <- function(id,
   checkmate::assert_class(data, "tdata")
 
   shiny::moduleServer(id, function(input, output, session) {
-    anl_selectors <- teal.transform::data_extract_multiple_srv(
+    anl_inputs <- teal.transform::merge_expression_module(
+      datasets = data,
       data_extract = list(arm_var = arm_var, hlt = hlt, llt = llt),
-      datasets = data,
-      join_keys = get_join_keys(data)
-    )
-
-    anl_merged_input <- teal.transform::merge_expression_srv(
-      selector_list = anl_selectors,
-      datasets = data,
       merge_function = "dplyr::inner_join",
       join_keys = get_join_keys(data)
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = list(arm_var = arm_var),
       anl_name = "ANL_ADSL",
       join_keys = get_join_keys(data)
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     validate_checks <- shiny::reactive({
@@ -722,9 +716,9 @@ srv_t_events_byterm <- function(id,
     })
 
     # The R-code corresponding to the analysis.
-    output_table <- shiny::reactive({
+    table_q <- shiny::reactive({
       validate_checks()
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]] # nolint
 
       input_hlt <- as.vector(merged$anl_input_r()$columns_source$hlt)
       input_llt <- as.vector(merged$anl_input_r()$columns_source$llt)
@@ -748,12 +742,12 @@ srv_t_events_byterm <- function(id,
         basic_table_args = basic_table_args
       )
 
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Outputs to render.
     table_r <- shiny::reactive({
-      output_table()[["pruned_and_sorted_result"]]
+      table_q()[["pruned_and_sorted_result"]]
     })
 
     teal.widgets::table_with_settings_srv(
@@ -763,15 +757,15 @@ srv_t_events_byterm <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_table())),
+      verbatim_content = reactive(teal.code::get_warnings(table_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_table())))
+      disabled = reactive(is.null(teal.code::get_warnings(table_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_table())),
+      verbatim_content = reactive(teal.code::get_code(table_q())),
       title = label
     )
 
@@ -790,7 +784,7 @@ srv_t_events_byterm <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_table()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(table_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_events.R
+++ b/R/tm_t_events.R
@@ -666,8 +666,8 @@ srv_t_events_byterm <- function(id,
     )
 
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_arm_var <- as.vector(merged$anl_input_r()$columns_source$arm_var)
       input_level_term <- c(

--- a/R/tm_t_events_by_grade.R
+++ b/R/tm_t_events_by_grade.R
@@ -987,30 +987,30 @@ srv_t_events_by_grade <- function(id,
   checkmate::assert_class(data, "tdata")
 
   shiny::moduleServer(id, function(input, output, session) {
-    anl_merged_input <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = list(arm_var = arm_var, hlt = hlt, llt = llt, grade = grade),
       join_keys = get_join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = list(arm_var = arm_var),
       join_keys = get_join_keys(data),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     validate_checks <- shiny::reactive({
@@ -1082,9 +1082,9 @@ srv_t_events_by_grade <- function(id,
     })
 
     # The R-code corresponding to the analysis.
-    output_table <- shiny::reactive({
+    table_q <- shiny::reactive({
       validate_checks()
-      ANL <- merged$anl_q_r()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]] # nolint
       adsl_keys <- merged$adsl_input_r()$keys
 
       input_hlt <- as.vector(merged$anl_input_r()$columns_source$hlt)
@@ -1133,12 +1133,12 @@ srv_t_events_by_grade <- function(id,
           basic_table_args = basic_table_args
         )
       }
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Outputs to render.
     table_r <- shiny::reactive({
-      output_table()[["pruned_and_sorted_result"]]
+      table_q()[["pruned_and_sorted_result"]]
     })
 
     teal.widgets::table_with_settings_srv(
@@ -1148,15 +1148,15 @@ srv_t_events_by_grade <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_table())),
+      verbatim_content = reactive(teal.code::get_warnings(table_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_table())))
+      disabled = reactive(is.null(teal.code::get_warnings(table_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_table())),
+      verbatim_content = reactive(teal.code::get_code(table_q())),
       title = label
     )
 
@@ -1175,7 +1175,7 @@ srv_t_events_by_grade <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_table()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(table_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_events_by_grade.R
+++ b/R/tm_t_events_by_grade.R
@@ -1014,8 +1014,8 @@ srv_t_events_by_grade <- function(id,
     )
 
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
       adsl_keys <- merged$adsl_input_r()$keys
 
       input_arm_var <- as.vector(merged$anl_input_r()$columns_source$arm_var)

--- a/R/tm_t_events_patyear.R
+++ b/R/tm_t_events_patyear.R
@@ -438,8 +438,8 @@ srv_events_patyear <- function(id,
 
     # Prepare the analysis environment (filter data, check data, populate envir).
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_arm_var <- as.vector(merged$anl_input_r()$columns_source$arm_var)
       input_aval_var <- as.vector(merged$anl_input_r()$columns_source$aval_var)

--- a/R/tm_t_events_summary.R
+++ b/R/tm_t_events_summary.R
@@ -860,8 +860,8 @@ srv_t_events_summary <- function(id,
     )
 
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_arm_var <- as.vector(merged$anl_input_r()$columns_source$arm_var)
       input_dthfl_var <- as.vector(merged$anl_input_r()$columns_source$dthfl_var)

--- a/R/tm_t_events_summary.R
+++ b/R/tm_t_events_summary.R
@@ -833,35 +833,30 @@ srv_t_events_summary <- function(id,
       data_extract_vars[["flag_var_aesi"]] <- flag_var_aesi
     }
 
-    anl_selectors <- teal.transform::data_extract_multiple_srv(
-      data_extract_vars,
-      datasets = data
-    )
-
-    anl_merged_input <- teal.transform::merge_expression_srv(
-      selector_list = anl_selectors,
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
+      data_extract = data_extract_vars,
       join_keys = get_join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       data_extract = Filter(Negate(is.null), list(arm_var = arm_var, dthfl_var = dthfl_var, dcsreas_var = dcsreas_var)),
       join_keys = get_join_keys(data),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     validate_checks <- shiny::reactive({
@@ -911,7 +906,7 @@ srv_t_events_summary <- function(id,
     })
 
     # The R-code corresponding to the analysis.
-    output_table <- shiny::reactive({
+    table_q <- shiny::reactive({
       validate_checks()
 
       input_flag_var_anl <- if (!is.null(flag_var_anl)) {
@@ -943,7 +938,7 @@ srv_t_events_summary <- function(id,
 
       all_basic_table_args <- teal.widgets::resolve_basic_table_args(user_table = basic_table_args)
       teal.code::eval_code(
-        merged$anl_q_r(),
+        merged$anl_q(),
         as.expression(my_calls)
       ) %>%
         teal.code::eval_code(
@@ -965,7 +960,7 @@ srv_t_events_summary <- function(id,
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_table()[["result"]])
+    table_r <- shiny::reactive(table_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -974,14 +969,14 @@ srv_t_events_summary <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_table())),
+      verbatim_content = reactive(teal.code::get_warnings(table_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_table())))
+      disabled = reactive(is.null(teal.code::get_warnings(table_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_table())),
+      verbatim_content = reactive(teal.code::get_code(table_q())),
       title = label
     )
 
@@ -1000,7 +995,7 @@ srv_t_events_summary <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_table()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(table_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_exposure.R
+++ b/R/tm_t_exposure.R
@@ -491,7 +491,7 @@ srv_t_exposure <- function(id,
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "tdata")
   shiny::moduleServer(id, function(input, output, session) {
-    anl_merged_input <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(
@@ -506,23 +506,23 @@ srv_t_exposure <- function(id,
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(col_by_var = col_by_var),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     validate_checks <- shiny::reactive({
@@ -570,15 +570,15 @@ srv_t_exposure <- function(id,
       NULL
     })
 
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
       anl_filtered <- data[[dataname]]()
       input_avalu_var <- as.character(
-        unique(merged$anl_q_r()[["ANL"]][[names(merged$anl_input_r()$columns_source$avalu_var)[1]]])
+        unique(merged$anl_q()[["ANL"]][[names(merged$anl_input_r()$columns_source$avalu_var)[1]]])
       )
       input_paramcd <- as.character(
-        unique(merged$anl_q_r()[["ANL"]][[names(merged$anl_input_r()$columns_source$paramcd)[1]]])
+        unique(merged$anl_q()[["ANL"]][[names(merged$anl_input_r()$columns_source$paramcd)[1]]])
       )
 
       if (is.null(paramcd_label)) {
@@ -609,11 +609,11 @@ srv_t_exposure <- function(id,
         avalu_var <- input_avalu_var,
         basic_table_args = basic_table_args
       )
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -622,15 +622,15 @@ srv_t_exposure <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -649,7 +649,7 @@ srv_t_exposure <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_exposure.R
+++ b/R/tm_t_exposure.R
@@ -526,8 +526,8 @@ srv_t_exposure <- function(id,
     )
 
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_paramcd <- unlist(paramcd$filter)["vars_selected"]
       input_id_var <- names(merged$anl_input_r()$columns_source$id_var)
@@ -573,7 +573,7 @@ srv_t_exposure <- function(id,
     all_q <- shiny::reactive({
       validate_checks()
 
-      anl_filtered <- data[[dataname]]()
+      anl_filtered <- merged$anl_q()[[dataname]]
       input_avalu_var <- as.character(
         unique(merged$anl_q()[["ANL"]][[names(merged$anl_input_r()$columns_source$avalu_var)[1]]])
       )

--- a/R/tm_t_logistic.R
+++ b/R/tm_t_logistic.R
@@ -544,8 +544,8 @@ srv_t_logistic <- function(id,
     })
 
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- anl_q()[[parentname]]
+      anl_filtered <- anl_q()[[dataname]]
 
       input_arm_var <- as.vector(merged$anl_input_r()$columns_source$arm_var)
       input_avalc_var <- as.vector(merged$anl_input_r()$columns_source$avalc_var)

--- a/R/tm_t_mult_events.R
+++ b/R/tm_t_mult_events.R
@@ -590,7 +590,7 @@ srv_t_mult_events_byterm <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(get_rcode(teal.code::get_code(all_q())), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_mult_events.R
+++ b/R/tm_t_mult_events.R
@@ -480,7 +480,7 @@ srv_t_mult_events_byterm <- function(id,
       anl_name = "ANL_ADSL"
     )
 
-    merged_data_q <- reactive({
+    anl_q <- reactive({
       q1 <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
       q2 <- teal.code::eval_code(q1, as.expression(anl_merge_inputs()$expr))
       teal.code::eval_code(q2, as.expression(adsl_merge_inputs()$expr))
@@ -518,10 +518,10 @@ srv_t_mult_events_byterm <- function(id,
     })
 
     # The R-code corresponding to the analysis.
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
-      q1 <- merged_data_q()
+      q1 <- anl_q()
       anl_m <- anl_merge_inputs()
 
       input_hlt <- names(anl_m$columns_source$hlt)
@@ -557,21 +557,21 @@ srv_t_mult_events_byterm <- function(id,
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(id = "table", table_r = table_r)
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -590,7 +590,7 @@ srv_t_mult_events_byterm <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(get_rcode(teal.code::get_code(output_q())), collapse = "\n"))
+        card$append_src(paste(get_rcode(teal.code::get_code(all_q())), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_mult_events.R
+++ b/R/tm_t_mult_events.R
@@ -481,14 +481,14 @@ srv_t_mult_events_byterm <- function(id,
     )
 
     anl_q <- reactive({
-      q1 <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      q2 <- teal.code::eval_code(q1, as.expression(anl_merge_inputs()$expr))
-      teal.code::eval_code(q2, as.expression(adsl_merge_inputs()$expr))
+      qenv <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
+      qenv2 <- teal.code::eval_code(qenv, as.expression(anl_merge_inputs()$expr))
+      teal.code::eval_code(qenv2, as.expression(adsl_merge_inputs()$expr))
     })
 
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- anl_q()[[parentname]]
+      anl_filtered <- anl_q()[[dataname]]
 
       anl_m <- anl_merge_inputs()
       input_arm_var <- as.vector(anl_m$columns_source$arm_var)
@@ -521,14 +521,14 @@ srv_t_mult_events_byterm <- function(id,
     all_q <- shiny::reactive({
       validate_checks()
 
-      q1 <- anl_q()
+      qenv <- anl_q()
       anl_m <- anl_merge_inputs()
 
       input_hlt <- names(anl_m$columns_source$hlt)
       input_llt <- names(anl_m$columns_source$llt)
 
-      hlt_labels <- mapply(function(x) rtables::obj_label(q1[["ANL"]][[x]]), input_hlt)
-      llt_labels <- mapply(function(x) rtables::obj_label(q1[["ANL"]][[x]]), input_llt)
+      hlt_labels <- mapply(function(x) rtables::obj_label(qenv[["ANL"]][[x]]), input_hlt)
+      llt_labels <- mapply(function(x) rtables::obj_label(qenv[["ANL"]][[x]]), input_llt)
 
       basic_table_args$title <- ifelse(
         is.null(basic_table_args$title),
@@ -553,7 +553,7 @@ srv_t_mult_events_byterm <- function(id,
         drop_arm_levels = input$drop_arm_levels,
         basic_table_args = basic_table_args
       )
-      teal.code::eval_code(q1, as.expression(my_calls))
+      teal.code::eval_code(qenv, as.expression(my_calls))
     })
 
     # Outputs to render.

--- a/R/tm_t_pp_medical_history.R
+++ b/R/tm_t_pp_medical_history.R
@@ -266,19 +266,19 @@ srv_t_medical_history <- function(id,
     )
 
     # Medical history tab ----
-    merge_input_r <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(mhterm = mhterm, mhbodsys = mhbodsys, mhdistat = mhdistat),
       merge_function = "dplyr::left_join"
     )
 
-    merge_q_r <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(merge_input_r()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr))
     })
 
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       shiny::validate(shiny::need(patient_id(), "Please select a patient."))
 
       shiny::validate(
@@ -295,7 +295,7 @@ srv_t_medical_history <- function(id,
           "Please select MHDISTAT variable."
         ),
         shiny::need(
-          nrow(merge_q_r()[["ANL"]][merge_q_r()[["ANL"]][[patient_col]] == patient_id(), ]) > 0,
+          nrow(anl_q()[["ANL"]][anl_q()[["ANL"]][[patient_col]] == patient_id(), ]) > 0,
           "Patient has no data about medical history."
         )
       )
@@ -308,7 +308,7 @@ srv_t_medical_history <- function(id,
       )
 
       teal.code::eval_code(
-        merge_q_r(),
+        anl_q(),
         substitute(
           expr = {
             ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
@@ -321,7 +321,7 @@ srv_t_medical_history <- function(id,
         teal.code::eval_code(as.expression(my_calls))
     })
 
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -330,14 +330,14 @@ srv_t_medical_history <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -356,7 +356,7 @@ srv_t_medical_history <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_pp_prior_medication.R
+++ b/R/tm_t_pp_prior_medication.R
@@ -298,19 +298,19 @@ srv_t_prior_medication <- function(id,
     )
 
     # Prior medication tab ----
-    merge_input_r <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(atirel = atirel, cmdecod = cmdecod, cmindc = cmindc, cmstdy = cmstdy),
       merge_function = "dplyr::left_join"
     )
 
-    merge_q_r <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(merge_input_r()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr))
     })
 
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       shiny::validate(shiny::need(patient_id(), "Please select a patient."))
 
       shiny::validate(
@@ -341,7 +341,7 @@ srv_t_prior_medication <- function(id,
       )
 
       teal.code::eval_code(
-        merge_q_r(),
+        anl_q(),
         substitute(
           expr = {
             ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
@@ -354,7 +354,7 @@ srv_t_prior_medication <- function(id,
         teal.code::eval_code(as.expression(my_calls))
     })
 
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
 
     output$prior_medication_table <- DT::renderDataTable(
       expr = table_r(),
@@ -363,14 +363,14 @@ srv_t_prior_medication <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -388,7 +388,7 @@ srv_t_prior_medication <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_shift_by_arm.R
+++ b/R/tm_t_shift_by_arm.R
@@ -429,8 +429,8 @@ srv_shift_by_arm <- function(id,
 
     # validate inputs
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_arm_var <- names(merged$anl_input_r()$columns_source$arm_var)
       input_aval_var <- names(merged$anl_input_r()$columns_source$aval_var)

--- a/R/tm_t_shift_by_arm.R
+++ b/R/tm_t_shift_by_arm.R
@@ -394,7 +394,7 @@ srv_shift_by_arm <- function(id,
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "tdata")
   shiny::moduleServer(id, function(input, output, session) {
-    anl_merged_input <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(
@@ -408,23 +408,23 @@ srv_shift_by_arm <- function(id,
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(arm_var = arm_var),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     # validate inputs
@@ -440,7 +440,7 @@ srv_shift_by_arm <- function(id,
       shiny::validate(
         shiny::need(input_arm_var, "Please select a treatment variable"),
         shiny::need(
-          nrow(merged$anl_q_r()[["ANL"]]) > 0,
+          nrow(merged$anl_q()[["ANL"]]) > 0,
           paste0(
             "Please make sure the analysis dataset is not empty or\n",
             "endpoint parameter and analysis visit are selected."
@@ -460,7 +460,7 @@ srv_shift_by_arm <- function(id,
     })
 
     # generate r code for the analysis
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
       my_calls <- template_shift_by_arm(
@@ -478,11 +478,11 @@ srv_shift_by_arm <- function(id,
         basic_table_args = basic_table_args
       )
 
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -492,15 +492,15 @@ srv_shift_by_arm <- function(id,
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     ### REPORTER
@@ -518,7 +518,7 @@ srv_shift_by_arm <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_shift_by_arm_by_worst.R
+++ b/R/tm_t_shift_by_arm_by_worst.R
@@ -417,7 +417,7 @@ srv_shift_by_arm_by_worst <- function(id,
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "tdata")
   shiny::moduleServer(id, function(input, output, session) {
-    anl_merged_input <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(
@@ -431,23 +431,23 @@ srv_shift_by_arm_by_worst <- function(id,
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(arm_var = arm_var),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     # validate inputs
@@ -464,7 +464,7 @@ srv_shift_by_arm_by_worst <- function(id,
       shiny::validate(
         shiny::need(input_arm_var, "Please select a treatment variable"),
         shiny::need(
-          nrow(merged$anl_q_r()[["ANL"]]) > 0,
+          nrow(merged$anl_q()[["ANL"]]) > 0,
           paste0(
             "Please make sure the analysis dataset is not empty or\n",
             "endpoint parameter and analysis visit are selected."
@@ -499,7 +499,7 @@ srv_shift_by_arm_by_worst <- function(id,
     })
 
     # generate r code for the analysis
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
       my_calls <- template_shift_by_arm_by_worst(
@@ -519,11 +519,11 @@ srv_shift_by_arm_by_worst <- function(id,
         basic_table_args = basic_table_args
       )
 
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -532,15 +532,15 @@ srv_shift_by_arm_by_worst <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -559,7 +559,7 @@ srv_shift_by_arm_by_worst <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_shift_by_arm_by_worst.R
+++ b/R/tm_t_shift_by_arm_by_worst.R
@@ -452,8 +452,8 @@ srv_shift_by_arm_by_worst <- function(id,
 
     # validate inputs
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_arm_var <- names(merged$anl_input_r()$columns_source$arm_var)
       input_aval_var <- names(merged$anl_input_r()$columns_source$aval_var)

--- a/R/tm_t_shift_by_arm_by_worst.R
+++ b/R/tm_t_shift_by_arm_by_worst.R
@@ -474,14 +474,14 @@ srv_shift_by_arm_by_worst <- function(id,
         shiny::need(input$treatment_flag, "Please select indicator value for on treatment records."),
         shiny::need(input_worst_flag_var, "Please select a worst flag variable."),
         shiny::need(
-          length(unique(anl_m$data()[[input_aval_var]])) < 50,
+          length(unique(merged$anl_q()[["ANL"]][[input_aval_var]])) < 50,
           paste(
             "There are too many values of", input_aval_var, "for the selected endpoint.",
             "Please select either a different endpoint or a different analysis value."
           )
         ),
         shiny::need(
-          length(unique(anl_m$data()[[input_base_var]])) < 50,
+          length(unique(merged$anl_q()[["ANL"]][[input_base_var]])) < 50,
           paste(
             "There are too many values of", input_base_var, "for the selected endpoint.",
             "Please select either a different endpoint or a different baseline value."

--- a/R/tm_t_shift_by_grade.R
+++ b/R/tm_t_shift_by_grade.R
@@ -786,8 +786,8 @@ srv_t_shift_by_grade <- function(id,
     )
 
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_arm_var <- names(merged$anl_input_r()$columns_source$arm_var)
       input_id_var <- names(merged$anl_input_r()$columns_source$id_var)

--- a/R/tm_t_shift_by_grade.R
+++ b/R/tm_t_shift_by_grade.R
@@ -524,8 +524,8 @@ template_shift_by_grade <- function(parentname,
 #'     ADSL = list(SAFFL = "Y")
 #'   )
 #' )
-#' \dontrun{
-#' shinyApp(app$ui, app$server)
+#' if (interactive()) {
+#'   shinyApp(app$ui, app$server)
 #' }
 #'
 tm_t_shift_by_grade <- function(label,

--- a/R/tm_t_shift_by_grade.R
+++ b/R/tm_t_shift_by_grade.R
@@ -751,7 +751,7 @@ srv_t_shift_by_grade <- function(id,
   checkmate::assert_class(data, "tdata")
 
   shiny::moduleServer(id, function(input, output, session) {
-    anl_merged_input <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(
@@ -766,23 +766,23 @@ srv_t_shift_by_grade <- function(id,
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(arm_var = arm_var),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     validate_checks <- shiny::reactive({
@@ -818,7 +818,7 @@ srv_t_shift_by_grade <- function(id,
       )
     })
 
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
       my_calls <- template_shift_by_grade(
@@ -839,11 +839,11 @@ srv_t_shift_by_grade <- function(id,
         basic_table_args = basic_table_args
       )
 
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -852,15 +852,15 @@ srv_t_shift_by_grade <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -879,7 +879,7 @@ srv_t_shift_by_grade <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_smq.R
+++ b/R/tm_t_smq.R
@@ -536,40 +536,36 @@ srv_t_smq <- function(id,
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "tdata")
   shiny::moduleServer(id, function(input, output, session) {
-    anl_selectors <- teal.transform::data_extract_multiple_srv(
-      list(
+    anl_inputs <- teal.transform::merge_expression_module(
+      datasets = data,
+      data_extract = list(
         arm_var = arm_var,
         id_var = id_var,
         baskets = baskets,
         scopes = scopes,
         llt = llt
       ),
-      datasets = data
-    )
-    anl_merged_input <- teal.transform::merge_expression_srv(
-      selector_list = anl_selectors,
-      datasets = data,
       join_keys = get_join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
       join_keys = get_join_keys(data),
       data_extract = list(arm_var = arm_var),
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     validate_checks <- shiny::reactive({
@@ -603,7 +599,7 @@ srv_t_smq <- function(id,
       )
     })
 
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
       my_calls <- template_smq(
@@ -620,11 +616,11 @@ srv_t_smq <- function(id,
         basic_table_args = basic_table_args
       )
 
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_q()[["pruned_and_sorted_result"]])
+    table_r <- shiny::reactive(all_q()[["pruned_and_sorted_result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -633,15 +629,15 @@ srv_t_smq <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -660,7 +656,7 @@ srv_t_smq <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_smq.R
+++ b/R/tm_t_smq.R
@@ -569,8 +569,8 @@ srv_t_smq <- function(id,
     )
 
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_arm_var <- names(merged$anl_input_r()$columns_source$arm_var)
       input_id_var <- names(merged$anl_input_r()$columns_source$id_var)

--- a/R/tm_t_summary.R
+++ b/R/tm_t_summary.R
@@ -424,7 +424,7 @@ srv_summary <- function(id,
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "tdata")
   shiny::moduleServer(id, function(input, output, session) {
-    anl_merged_input <- teal.transform::merge_expression_module(
+    anl_inputs <- teal.transform::merge_expression_module(
       id = "anl_merge",
       datasets = data,
       data_extract = list(arm_var = arm_var, summarize_vars = summarize_vars),
@@ -432,7 +432,7 @@ srv_summary <- function(id,
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       id = "adsl_merge",
       datasets = data,
       join_keys = get_join_keys(data),
@@ -440,16 +440,16 @@ srv_summary <- function(id,
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     shiny::observeEvent(merged$anl_input_r()$columns_source$summarize_vars, {
@@ -473,7 +473,7 @@ srv_summary <- function(id,
     validate_checks <- shiny::reactive({
       adsl_filtered <- data[[parentname]]()
       anl_filtered <- data[[dataname]]()
-      anl <- merged$anl_q_r()[["ANL"]]
+      anl <- merged$anl_q()[["ANL"]]
 
       # we take names of the columns source as they match names of the input data in merge_datasets
       # if we use $arm_var they might be renamed to <selector id>.arm_var
@@ -518,7 +518,7 @@ srv_summary <- function(id,
     })
 
     # generate r code for the analysis
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
       summarize_vars <- merged$anl_input_r()$columns_source$summarize_vars
@@ -539,24 +539,24 @@ srv_summary <- function(id,
         basic_table_args = basic_table_args
       )
 
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
     teal.widgets::table_with_settings_srv(id = "table", table_r = table_r)
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -575,7 +575,7 @@ srv_summary <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_summary.R
+++ b/R/tm_t_summary.R
@@ -471,8 +471,8 @@ srv_summary <- function(id,
 
     # validate inputs
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
       anl <- merged$anl_q()[["ANL"]]
 
       # we take names of the columns source as they match names of the input data in merge_datasets

--- a/R/tm_t_summary_by.R
+++ b/R/tm_t_summary_by.R
@@ -624,8 +624,8 @@ srv_summary_by <- function(id,
 
     # Prepare the analysis environment (filter data, check data, populate envir).
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- merged$anl_q()[[parentname]]
+      anl_filtered <- merged$anl_q()[[dataname]]
 
       input_arm_var <- names(merged$anl_input_r()$columns_source$arm_var)
       input_id_var <- names(merged$anl_input_r()$columns_source$id_var)
@@ -666,7 +666,7 @@ srv_summary_by <- function(id,
     all_q <- shiny::reactive({
       validate_checks()
       summarize_vars <- as.vector(merged$anl_input_r()$columns_source$summarize_vars)
-      var_labels <- formatters::var_labels(data[[dataname]]()[, summarize_vars, drop = FALSE])
+      var_labels <- formatters::var_labels(merged$anl_q()[[dataname]][, summarize_vars, drop = FALSE])
 
       my_calls <- template_summary_by(
         parentname = "ANL_ADSL",

--- a/R/tm_t_summary_by.R
+++ b/R/tm_t_summary_by.R
@@ -595,15 +595,14 @@ srv_summary_by <- function(id,
       vars[["paramcd"]] <- paramcd
     }
 
-    anl_selectors <- teal.transform::data_extract_multiple_srv(vars, datasets = data)
-    anl_merged_input <- teal.transform::merge_expression_srv(
-      selector_list = anl_selectors,
+    anl_inputs <- teal.transform::merge_expression_module(
+      data_extract = vars,
       datasets = data,
       join_keys = get_join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 
-    adsl_merged_input <- teal.transform::merge_expression_module(
+    adsl_inputs <- teal.transform::merge_expression_module(
       id = "adsl_merge",
       datasets = data,
       join_keys = get_join_keys(data),
@@ -611,16 +610,16 @@ srv_summary_by <- function(id,
       anl_name = "ANL_ADSL"
     )
 
-    anl_merged_q <- reactive({
+    anl_q <- reactive({
       teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
-        teal.code::eval_code(as.expression(anl_merged_input()$expr)) %>%
-        teal.code::eval_code(as.expression(adsl_merged_input()$expr))
+        teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
+        teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })
 
     merged <- list(
-      anl_input_r = anl_merged_input,
-      adsl_input_r = adsl_merged_input,
-      anl_q_r = anl_merged_q
+      anl_input_r = anl_inputs,
+      adsl_input_r = adsl_inputs,
+      anl_q = anl_q
     )
 
     # Prepare the analysis environment (filter data, check data, populate envir).
@@ -664,7 +663,7 @@ srv_summary_by <- function(id,
     })
 
     # The R-code corresponding to the analysis.
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
       summarize_vars <- as.vector(merged$anl_input_r()$columns_source$summarize_vars)
       var_labels <- formatters::var_labels(data[[dataname]]()[, summarize_vars, drop = FALSE])
@@ -689,11 +688,11 @@ srv_summary_by <- function(id,
         basic_table_args = basic_table_args
       )
 
-      teal.code::eval_code(merged$anl_q_r(), as.expression(my_calls))
+      teal.code::eval_code(merged$anl_q(), as.expression(my_calls))
     })
 
     # Outputs to render.
-    table_r <- shiny::reactive(output_q()[["result"]])
+    table_r <- shiny::reactive(all_q()[["result"]])
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -702,15 +701,15 @@ srv_summary_by <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     # Render R code.
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -729,7 +728,7 @@ srv_summary_by <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_tte.R
+++ b/R/tm_t_tte.R
@@ -754,9 +754,9 @@ srv_t_tte <- function(id,
     )
 
     anl_q <- reactive({
-      quo <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
-      quo1 <- teal.code::eval_code(quo, as.expression(anl_merge_inputs()$expr))
-      teal.code::eval_code(quo1, as.expression(adsl_merge_inputs()$expr))
+      qenv <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
+      qenv1 <- teal.code::eval_code(qenv, as.expression(anl_merge_inputs()$expr))
+      teal.code::eval_code(qenv1, as.expression(adsl_merge_inputs()$expr))
     })
 
     # Prepare the analysis environment (filter data, check data, populate envir).

--- a/R/tm_t_tte.R
+++ b/R/tm_t_tte.R
@@ -753,7 +753,7 @@ srv_t_tte <- function(id,
       anl_name = "ANL_ADSL"
     )
 
-    merged_q <- reactive({
+    anl_q <- reactive({
       quo <- teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data))
       quo1 <- teal.code::eval_code(quo, as.expression(anl_merge_inputs()$expr))
       teal.code::eval_code(quo1, as.expression(adsl_merge_inputs()$expr))
@@ -763,7 +763,7 @@ srv_t_tte <- function(id,
     validate_checks <- shiny::reactive({
       adsl_filtered <- data[[parentname]]()
       anl_filtered <- data[[dataname]]()
-      anl <- merged_q()[["ANL"]]
+      anl <- anl_q()[["ANL"]]
 
       anl_m <- anl_merge_inputs()
       input_arm_var <- as.vector(anl_m$columns_source$arm_var)
@@ -834,11 +834,11 @@ srv_t_tte <- function(id,
 
     # The R-code corresponding to the analysis.
 
-    output_q <- shiny::reactive({
+    all_q <- shiny::reactive({
       validate_checks()
 
       anl_m <- anl_merge_inputs()
-      q1 <- merged_q()
+      q1 <- anl_q()
 
       strata_var <- as.vector(anl_m$columns_source$strata_var)
 
@@ -880,20 +880,20 @@ srv_t_tte <- function(id,
       teal.code::eval_code(q1, as.expression(my_calls))
     })
 
-    table_r <- shiny::reactive(output_q()[["table"]])
+    table_r <- shiny::reactive(all_q()[["table"]])
 
     teal.widgets::table_with_settings_srv(id = "table", table_r = table_r)
 
     teal.widgets::verbatim_popup_srv(
       id = "warning",
-      verbatim_content = reactive(teal.code::get_warnings(output_q())),
+      verbatim_content = reactive(teal.code::get_warnings(all_q())),
       title = "Warning",
-      disabled = reactive(is.null(teal.code::get_warnings(output_q())))
+      disabled = reactive(is.null(teal.code::get_warnings(all_q())))
     )
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(output_q())),
+      verbatim_content = reactive(teal.code::get_code(all_q())),
       title = label
     )
 
@@ -912,7 +912,7 @@ srv_t_tte <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(paste(teal.code::get_code(output_q()), collapse = "\n"))
+        card$append_src(paste(teal.code::get_code(all_q()), collapse = "\n"))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/R/tm_t_tte.R
+++ b/R/tm_t_tte.R
@@ -761,8 +761,8 @@ srv_t_tte <- function(id,
 
     # Prepare the analysis environment (filter data, check data, populate envir).
     validate_checks <- shiny::reactive({
-      adsl_filtered <- data[[parentname]]()
-      anl_filtered <- data[[dataname]]()
+      adsl_filtered <- anl_q()[[parentname]]
+      anl_filtered <- anl_q()[[dataname]]
       anl <- anl_q()[["ANL"]]
 
       anl_m <- anl_merge_inputs()
@@ -838,7 +838,7 @@ srv_t_tte <- function(id,
       validate_checks()
 
       anl_m <- anl_merge_inputs()
-      q1 <- anl_q()
+      qenv <- anl_q()
 
       strata_var <- as.vector(anl_m$columns_source$strata_var)
 
@@ -877,7 +877,7 @@ srv_t_tte <- function(id,
         basic_table_args = basic_table_args
       )
 
-      teal.code::eval_code(q1, as.expression(my_calls))
+      teal.code::eval_code(qenv, as.expression(my_calls))
     })
 
     table_r <- shiny::reactive(all_q()[["table"]])

--- a/man/tm_t_shift_by_grade.Rd
+++ b/man/tm_t_shift_by_grade.Rd
@@ -158,8 +158,8 @@ app <- init(
     ADSL = list(SAFFL = "Y")
   )
 )
-\dontrun{
-shinyApp(app$ui, app$server)
+if (interactive()) {
+  shinyApp(app$ui, app$server)
 }
 
 }


### PR DESCRIPTION
closes #669

- `anl_inputs` merge_expression_module output
- `anl_q` for all reactives returning qenv with merged data 
- `all_q `reactives returning qenv with all code 
- `qenv`as an binding name instead of `q1` or `quo`
- After merge expression is evaluated `data` shouldn't be used anymore - we retrieve objects from qenv
- replaced `data_extract_multiple_srv` + `merge_expression_srv` with `merge_expression_module`

Please check 
- `teal.gallery::launch_app("efficacy")`
- `teal.gallery::launch_app("safety")`