### PR TITLE
Removing scda from examples using tern data

### DIFF
--- a/R/tm_t_pp_laboratory.R
+++ b/R/tm_t_pp_laboratory.R
@@ -108,9 +108,15 @@ template_laboratory <- function(dataname = "ANL",
 #' @export
 #'
 #' @examples
-#' library(scda)
-#' ADSL <- synthetic_cdisc_dataset("latest", "adsl")
-#' ADLB <- synthetic_cdisc_dataset("latest", "adlb")
+#'
+#' # Complete synthetic data
+#' ADSL <- scda::synthetic_cdisc_dataset("latest", "adsl")
+#' ADLB <- scda::synthetic_cdisc_dataset("latest", "adlb")
+#'
+#' # Reduced data from tern
+#' ADSL <- tern::tern_ex_adsl
+#' ADLB <- tern::tern_ex_adlb %>%
+#' dplyr::mutate(ADY = ceiling(as.numeric(difftime(.data$ADTM, .data$TRTSDTM, units = "days"))))
 #'
 #' app <- init(
 #'   data = cdisc_data(
@@ -155,7 +161,7 @@ template_laboratory <- function(dataname = "ANL",
 #' )
 #' if (interactive()) {
 #'   shinyApp(app$ui, app$server)
-#' }
+}
 #'
 tm_t_pp_laboratory <- function(label,
                                dataname = "ADLB",

--- a/R/tm_t_pp_laboratory.R
+++ b/R/tm_t_pp_laboratory.R
@@ -110,22 +110,18 @@ template_laboratory <- function(dataname = "ANL",
 #' @examples
 #'
 #' # Complete synthetic data
-#' ADSL <- scda::synthetic_cdisc_dataset("latest", "adsl")
-#' ADLB <- scda::synthetic_cdisc_dataset("latest", "adlb")
+#' # ADSL <- scda::synthetic_cdisc_dataset("latest", "adsl")
+#' # ADLB <- scda::synthetic_cdisc_dataset("latest", "adlb")
 #'
 #' # Reduced data from tern
 #' ADSL <- tern::tern_ex_adsl
 #' ADLB <- tern::tern_ex_adlb %>%
-#' dplyr::mutate(ADY = ceiling(as.numeric(difftime(.data$ADTM, .data$TRTSDTM, units = "days"))))
+#'   dplyr::mutate(ADY = ceiling(as.numeric(difftime(.data$ADTM, .data$TRTSDTM, units = "days"))))
 #'
 #' app <- init(
 #'   data = cdisc_data(
-#'     cdisc_dataset("ADSL", ADSL,
-#'       code = 'ADSL <- synthetic_cdisc_dataset("latest", "adsl")'
-#'     ),
-#'     cdisc_dataset("ADLB", ADLB,
-#'       code = 'ADLB <- synthetic_cdisc_dataset("latest", "adlb")'
-#'     )
+#'     cdisc_dataset("ADSL", ADSL),
+#'     cdisc_dataset("ADLB", ADLB)
 #'   ),
 #'   modules = modules(
 #'     tm_t_pp_laboratory(
@@ -161,7 +157,7 @@ template_laboratory <- function(dataname = "ANL",
 #' )
 #' if (interactive()) {
 #'   shinyApp(app$ui, app$server)
-}
+#' }
 #'
 tm_t_pp_laboratory <- function(label,
                                dataname = "ADLB",

--- a/R/tm_t_summary.R
+++ b/R/tm_t_summary.R
@@ -220,11 +220,8 @@ template_summary <- function(dataname,
 #' @export
 #' @examples
 #' # Preparation of the test case.
-#' library(dplyr)
-#' library(scda)
-#' library(tern)
 #'
-#' adsl <- synthetic_cdisc_dataset("latest", "adsl")
+#' adsl <- scda::synthetic_cdisc_dataset("latest", "adsl")
 #'
 #' # Include `EOSDY` and `DCSREAS` variables below because they contain missing data.
 #' stopifnot(
@@ -235,7 +232,6 @@ template_summary <- function(dataname,
 #' app <- init(
 #'   data = cdisc_data(
 #'     cdisc_dataset("ADSL", adsl),
-#'     code = 'ADSL <- synthetic_cdisc_dataset("latest", "adsl")',
 #'     check = TRUE
 #'   ),
 #'   modules = modules(

--- a/man/tm_t_pp_laboratory.Rd
+++ b/man/tm_t_pp_laboratory.Rd
@@ -61,18 +61,20 @@ the \code{\link[shiny:helpText]{shiny::helpText()}} elements are useful.}
 This teal module produces a patient profile laboratory table using ADaM datasets.
 }
 \examples{
-library(scda)
-ADSL <- synthetic_cdisc_dataset("latest", "adsl")
-ADLB <- synthetic_cdisc_dataset("latest", "adlb")
+
+# Complete synthetic data
+# ADSL <- scda::synthetic_cdisc_dataset("latest", "adsl")
+# ADLB <- scda::synthetic_cdisc_dataset("latest", "adlb")
+
+# Reduced data from tern
+ADSL <- tern::tern_ex_adsl
+ADLB <- tern::tern_ex_adlb \%>\%
+  dplyr::mutate(ADY = ceiling(as.numeric(difftime(.data$ADTM, .data$TRTSDTM, units = "days"))))
 
 app <- init(
   data = cdisc_data(
-    cdisc_dataset("ADSL", ADSL,
-      code = 'ADSL <- synthetic_cdisc_dataset("latest", "adsl")'
-    ),
-    cdisc_dataset("ADLB", ADLB,
-      code = 'ADLB <- synthetic_cdisc_dataset("latest", "adlb")'
-    )
+    cdisc_dataset("ADSL", ADSL),
+    cdisc_dataset("ADLB", ADLB)
   ),
   modules = modules(
     tm_t_pp_laboratory(

--- a/man/tm_t_summary.Rd
+++ b/man/tm_t_summary.Rd
@@ -87,11 +87,8 @@ Teal Module: Summary of Variables
 }
 \examples{
 # Preparation of the test case.
-library(dplyr)
-library(scda)
-library(tern)
 
-adsl <- synthetic_cdisc_dataset("latest", "adsl")
+adsl <- scda::synthetic_cdisc_dataset("latest", "adsl")
 
 # Include `EOSDY` and `DCSREAS` variables below because they contain missing data.
 stopifnot(
@@ -102,7 +99,6 @@ stopifnot(
 app <- init(
   data = cdisc_data(
     cdisc_dataset("ADSL", adsl),
-    code = 'ADSL <- synthetic_cdisc_dataset("latest", "adsl")',
     check = TRUE
   ),
   modules = modules(


### PR DESCRIPTION
Fixes #708 

I think it does not make sense to create again the data when tern is in `Depends:` and this would have only one step dependency (which is there anyway)