### PR TITLE
Remove `scda` and `scda.2022` from staged deps

### DIFF
--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -11,12 +11,6 @@ upstream_repos:
   insightsengineering/tern.gee:
     repo: insightsengineering/tern.gee
     host: https://github.com
-  insightsengineering/scda:
-    repo: insightsengineering/scda
-    host: https://github.com
-  insightsengineering/scda.2022:
-    repo: insightsengineering/scda.2022
-    host: https://github.com
   insightsengineering/rtables:
     repo: insightsengineering/rtables
     host: https://github.com


### PR DESCRIPTION
Closes #710 

Merge with https://github.com/insightsengineering/scda/pull/116 and https://github.com/insightsengineering/scda.2022/pull/107