### PR TITLE
quickstart_substitute.Rmd: fix wrong extension for SVG files

### DIFF
--- a/vignettes/quickstart_substitute.Rmd
+++ b/vignettes/quickstart_substitute.Rmd
@@ -17,7 +17,8 @@ vignette: >
 knitr::opts_chunk$set(
   purl = TRUE,
   collapse = TRUE,
-  dev = "svg"
+  dev = "svg",
+  fig.ext = "svg"
 )
 ```
 


### PR DESCRIPTION
# Pull Request

Fixes #741 
