### PR TITLE
Display Patient ID in relevant templates, clean up data tables in reports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,6 +43,7 @@ Imports:
     magrittr,
     methods,
     rlang,
+    rlistings (>= 0.2.4),
     rmarkdown,
     rtables (>= 0.6.1),
     scales,

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 * Improve default annotation table sizing in `tm_g_km`.
 * Refactored `tm_t_exposure` to display "total" row as last row in table instead of as a summary row. Added parameters `add_total_row` to set whether the total row should be displayed and `total_row_label` to set the total row label.
 * Update `tm_t_events` to maintain indentation after pruning.
+* Updated `tm_t_pp_basic_info`, `tm_t_pp_medical_history`, `tm_g_pp_therapy`, `tm_g_pp_adverse_events`, and `tm_t_pp_laboratory` to print patient ID above table.
+* Updated `tm_t_pp_basic_info`, `tm_g_pp_therapy`, `tm_g_pp_adverse_events`, and `tm_t_pp_laboratory` to use `rlistings` to print data neatly in reports.
 
 ### Miscellaneous
 * Updated `control_incidence_rate` parameter names in `tm_t_events_patyear` from `time_unit_input` and `time_unit_output` to `input_time_unit` and `num_pt_year`, respectively, after parameter names were changed in `tern`.

--- a/R/tm_g_pp_adverse_events.R
+++ b/R/tm_g_pp_adverse_events.R
@@ -53,6 +53,14 @@ template_adverse_events <- function(dataname = "ANL",
           ) %>%
           dplyr::arrange(dplyr::desc(tox_grade)) %>%
           `colnames<-`(get_labels(dataname)$column_labels[vars])
+
+        table <- as_listing(
+          table,
+          key_cols = NULL,
+          default_formatting = list(all = fmt_config(align = "left"))
+        )
+        main_title(table) <- paste("Patient ID:", patient_id)
+
         table
       },
       env = list(
@@ -64,7 +72,8 @@ template_adverse_events <- function(dataname = "ANL",
         action = as.name(action),
         time = as.name(time),
         decod = `if`(is.null(decod), NULL, as.name(decod)),
-        vars = c(aeterm, tox_grade, causality, outcome, action, time, decod)
+        vars = c(aeterm, tox_grade, causality, outcome, action, time, decod),
+        patient_id = patient_id
       )
     )
   )
@@ -574,7 +583,6 @@ srv_g_adverse_events <- function(id,
           card$append_fs(filter_panel_api$get_filter_state())
         }
         card$append_text("Table", "header3")
-        card$append_text(paste("Patient ID:", all_q()[["pt_id"]]), "verbatim")
         card$append_table(teal.code::dev_suppress(all_q()[["table"]]))
         card$append_text("Plot", "header3")
         card$append_plot(plot_r(), dim = pws$dim())

--- a/R/tm_g_pp_adverse_events.R
+++ b/R/tm_g_pp_adverse_events.R
@@ -54,7 +54,7 @@ template_adverse_events <- function(dataname = "ANL",
           dplyr::arrange(dplyr::desc(tox_grade)) %>%
           `colnames<-`(get_labels(dataname)$column_labels[vars])
 
-        table <- as_listing(
+        table <- rlistings::as_listing(
           table,
           key_cols = NULL,
           default_formatting = list(all = fmt_config(align = "left"))
@@ -320,7 +320,7 @@ ui_g_adverse_events <- function(id, ...) {
   ns <- shiny::NS(id)
   teal.widgets::standard_layout(
     output = shiny::div(
-      htmlOutput(ns("title")),
+      shiny::htmlOutput(ns("title")),
       teal.widgets::get_dt_rows(ns("table"), ns("table_rows")),
       DT::DTOutput(outputId = ns("table")),
       teal.widgets::plot_with_settings_ui(id = ns("chart"))
@@ -539,7 +539,7 @@ srv_g_adverse_events <- function(id,
       teal.code::eval_code(qenv2, as.expression(calls))
     })
 
-    output$title <- renderText({
+    output$title <- shiny::renderText({
       paste("<h5><b>Patient ID:", all_q()[["pt_id"]], "</b></h5>")
     })
 

--- a/R/tm_g_pp_adverse_events.R
+++ b/R/tm_g_pp_adverse_events.R
@@ -311,6 +311,7 @@ ui_g_adverse_events <- function(id, ...) {
   ns <- shiny::NS(id)
   teal.widgets::standard_layout(
     output = shiny::div(
+      htmlOutput(ns("title")),
       teal.widgets::get_dt_rows(ns("table"), ns("table_rows")),
       DT::DTOutput(outputId = ns("table")),
       teal.widgets::plot_with_settings_ui(id = ns("chart"))
@@ -502,8 +503,10 @@ srv_g_adverse_events <- function(id,
       qenv2 <- teal.code::eval_code(
         qenv,
         substitute(
-          expr = ANL <- ANL[ANL[[patient_col]] == patient_id, ], # nolint
-          env = list(
+          expr = {
+            pt_id <- patient_id
+            ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
+          }, env = list(
             patient_col = patient_col,
             patient_id = patient_id()
           )
@@ -526,6 +529,11 @@ srv_g_adverse_events <- function(id,
 
       teal.code::eval_code(qenv2, as.expression(calls))
     })
+
+    output$title <- renderText({
+      paste("<h5><b>Patient ID:", all_q()[["pt_id"]], "</b></h5>")
+    })
+
     output$table <- DT::renderDataTable(
       expr = teal.code::dev_suppress(all_q()[["table"]]),
       options = list(pageLength = input$table_rows)
@@ -560,11 +568,14 @@ srv_g_adverse_events <- function(id,
     if (with_reporter) {
       card_fun <- function(comment) {
         card <- teal::TealReportCard$new()
-        card$set_name("Patient Profile Adverse Events Plot")
-        card$append_text("Patient Profile Adverse Events Plot", "header2")
+        card$set_name("Patient Profile Adverse Events")
+        card$append_text("Patient Profile Adverse Events", "header2")
         if (with_filter) {
           card$append_fs(filter_panel_api$get_filter_state())
         }
+        card$append_text("Table", "header3")
+        card$append_text(paste("Patient ID:", all_q()[["pt_id"]]), "verbatim")
+        card$append_table(teal.code::dev_suppress(all_q()[["table"]]))
         card$append_text("Plot", "header3")
         card$append_plot(plot_r(), dim = pws$dim())
         if (!comment == "") {

--- a/R/tm_g_pp_therapy.R
+++ b/R/tm_g_pp_therapy.R
@@ -87,6 +87,14 @@ template_therapy <- function(dataname = "ANL",
           get_labels(dataname)$column_labels[c(cmindc_char, cmdecod_char)], "Dosage",
           get_labels(dataname)$column_labels[c(cmstdy_char, cmendy_char)]
         ))
+
+      therapy_table <- as_listing(
+        therapy_table,
+        key_cols = NULL,
+        default_formatting = list(all = fmt_config(align = "left"))
+      )
+      main_title(therapy_table) <- paste("Patient ID:", patient_id)
+
       therapy_table
     }, env = list(
       dataname = as.name(dataname),
@@ -108,7 +116,8 @@ template_therapy <- function(dataname = "ANL",
       cmroute_char = cmroute,
       cmdosfrq_char = cmdosfrq,
       cmendy_char = cmendy,
-      cmstdy_char = cmstdy
+      cmstdy_char = cmstdy,
+      patient_id = patient_id
     ))
   )
 
@@ -696,7 +705,6 @@ srv_g_therapy <- function(id,
           card$append_fs(filter_panel_api$get_filter_state())
         }
         card$append_text("Table", "header3")
-        card$append_text(paste("Patient ID:", all_q()[["pt_id"]]), "verbatim")
         card$append_table(teal.code::dev_suppress(all_q()[["therapy_table"]]))
         card$append_text("Plot", "header3")
         card$append_plot(plot_r(), dim = pws$dim())

--- a/R/tm_g_pp_therapy.R
+++ b/R/tm_g_pp_therapy.R
@@ -411,6 +411,7 @@ ui_g_therapy <- function(id, ...) {
   ns <- shiny::NS(id)
   teal.widgets::standard_layout(
     output = shiny::div(
+      htmlOutput(ns("title")),
       teal.widgets::get_dt_rows(ns("therapy_table"), ns("therapy_table_rows")),
       DT::DTOutput(outputId = ns("therapy_table")),
       teal.widgets::plot_with_settings_ui(id = ns("therapy_plot"))
@@ -638,6 +639,7 @@ srv_g_therapy <- function(id,
         merged$anl_q(),
         substitute(
           expr = {
+            pt_id <- patient_id
             ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
           }, env = list(
             patient_col = patient_col,
@@ -646,6 +648,10 @@ srv_g_therapy <- function(id,
         )
       ) %>%
         teal.code::eval_code(as.expression(my_calls))
+    })
+
+    output$title <- renderText({
+      paste("<h5><b>Patient ID:", all_q()[["pt_id"]], "</b></h5>")
     })
 
     output$therapy_table <- DT::renderDataTable(
@@ -684,11 +690,14 @@ srv_g_therapy <- function(id,
     if (with_reporter) {
       card_fun <- function(comment) {
         card <- teal::TealReportCard$new()
-        card$set_name("Patient Profile Therapy Plot")
-        card$append_text("Patient Profile Therapy Plot", "header2")
+        card$set_name("Patient Profile Therapy")
+        card$append_text("Patient Profile Therapy", "header2")
         if (with_filter) {
           card$append_fs(filter_panel_api$get_filter_state())
         }
+        card$append_text("Table", "header3")
+        card$append_text(paste("Patient ID:", all_q()[["pt_id"]]), "verbatim")
+        card$append_table(teal.code::dev_suppress(all_q()[["therapy_table"]]))
         card$append_text("Plot", "header3")
         card$append_plot(plot_r(), dim = pws$dim())
         if (!comment == "") {

--- a/R/tm_g_pp_therapy.R
+++ b/R/tm_g_pp_therapy.R
@@ -181,10 +181,9 @@ template_therapy <- function(dataname = "ANL",
         ggplot2::ggplot(data = data, ggplot2::aes(fill = cmindc, color = cmindc, y = CMDECOD, x = CMSTDY)) +
         ggplot2::geom_segment(ggplot2::aes(xend = CMENDY, yend = CMDECOD), size = 2) +
         ggplot2::geom_text(
-          data =
-            data %>%
-              dplyr::select(CMDECOD, cmindc, CMSTDY) %>%
-              dplyr::distinct(),
+          data = data %>%
+            dplyr::select(CMDECOD, cmindc, CMSTDY) %>%
+            dplyr::distinct(),
           ggplot2::aes(x = CMSTDY, label = CMDECOD), color = "black",
           hjust = "left",
           vjust = "bottom",

--- a/R/tm_g_pp_therapy.R
+++ b/R/tm_g_pp_therapy.R
@@ -88,7 +88,7 @@ template_therapy <- function(dataname = "ANL",
           get_labels(dataname)$column_labels[c(cmstdy_char, cmendy_char)]
         ))
 
-      therapy_table <- as_listing(
+      therapy_table <- rlistings::as_listing(
         therapy_table,
         key_cols = NULL,
         default_formatting = list(all = fmt_config(align = "left"))
@@ -420,7 +420,7 @@ ui_g_therapy <- function(id, ...) {
   ns <- shiny::NS(id)
   teal.widgets::standard_layout(
     output = shiny::div(
-      htmlOutput(ns("title")),
+      shiny::htmlOutput(ns("title")),
       teal.widgets::get_dt_rows(ns("therapy_table"), ns("therapy_table_rows")),
       DT::DTOutput(outputId = ns("therapy_table")),
       teal.widgets::plot_with_settings_ui(id = ns("therapy_plot"))
@@ -659,7 +659,7 @@ srv_g_therapy <- function(id,
         teal.code::eval_code(as.expression(my_calls))
     })
 
-    output$title <- renderText({
+    output$title <- shiny::renderText({
       paste("<h5><b>Patient ID:", all_q()[["pt_id"]], "</b></h5>")
     })
 

--- a/R/tm_t_pp_basic_info.R
+++ b/R/tm_t_pp_basic_info.R
@@ -119,6 +119,7 @@ ui_t_basic_info <- function(id, ...) {
   ns <- shiny::NS(id)
   teal.widgets::standard_layout(
     output = shiny::div(
+      htmlOutput(ns("title")),
       DT::DTOutput(outputId = ns("basic_info_table"))
     ),
     encoding = shiny::div(
@@ -228,6 +229,7 @@ srv_t_basic_info <- function(id,
         anl_q(),
         substitute(
           expr = {
+            pt_id <- patient_id
             ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
           }, env = list(
             patient_col = patient_col,
@@ -236,6 +238,10 @@ srv_t_basic_info <- function(id,
         )
       ) %>%
         teal.code::eval_code(as.expression(my_calls))
+    })
+
+    output$title <- renderText({
+      paste("<h5><b>Patient ID:", all_q()[["pt_id"]], "</b></h5>")
     })
 
     table_r <- shiny::reactive(all_q()[["result"]])
@@ -264,12 +270,13 @@ srv_t_basic_info <- function(id,
     if (with_reporter) {
       card_fun <- function(comment) {
         card <- teal::TealReportCard$new()
-        card$set_name("Patient Profile Basic Info Table")
-        card$append_text("Patient Profile Basic Info Table", "header2")
+        card$set_name("Patient Profile Basic Info")
+        card$append_text("Patient Profile Basic Info", "header2")
         if (with_filter) {
           card$append_fs(filter_panel_api$get_filter_state())
         }
         card$append_text("Table", "header3")
+        card$append_text(paste("Patient ID:", all_q()[["pt_id"]]), "verbatim")
         card$append_table(table_r())
         if (!comment == "") {
           card$append_text("Comment", "header3")

--- a/R/tm_t_pp_basic_info.R
+++ b/R/tm_t_pp_basic_info.R
@@ -33,7 +33,7 @@ template_basic_info <- function(dataname = "ANL",
           dplyr::select(var, key, value) %>%
           dplyr::rename(` ` = var, `  ` = key, `   ` = value)
 
-        result <- as_listing(
+        result <- rlistings::as_listing(
           result,
           default_formatting = list(all = fmt_config(align = "left"))
         )
@@ -129,7 +129,7 @@ ui_t_basic_info <- function(id, ...) {
   ns <- shiny::NS(id)
   teal.widgets::standard_layout(
     output = shiny::div(
-      htmlOutput(ns("title")),
+      shiny::htmlOutput(ns("title")),
       DT::DTOutput(outputId = ns("basic_info_table"))
     ),
     encoding = shiny::div(
@@ -251,7 +251,7 @@ srv_t_basic_info <- function(id,
         teal.code::eval_code(as.expression(my_calls))
     })
 
-    output$title <- renderText({
+    output$title <- shiny::renderText({
       paste("<h5><b>Patient ID:", all_q()[["pt_id"]], "</b></h5>")
     })
 

--- a/R/tm_t_pp_laboratory.R
+++ b/R/tm_t_pp_laboratory.R
@@ -55,7 +55,7 @@ template_laboratory <- function(dataname = "ANL",
           tidyr::pivot_wider(names_from = INDEX, values_from = aval_anrind) %>%
           dplyr::mutate(param_char := clean_description(.data[[param_char]]))
 
-        labor_table_raw <- as_listing(
+        labor_table_raw <- rlistings::as_listing(
           labor_table_raw,
           key_cols = NULL,
           default_formatting = list(all = fmt_config(align = "left"))
@@ -224,7 +224,7 @@ ui_g_laboratory <- function(id, ...) {
   ns <- shiny::NS(id)
   teal.widgets::standard_layout(
     output = shiny::div(
-      htmlOutput(ns("title")),
+      shiny::htmlOutput(ns("title")),
       DT::DTOutput(outputId = ns("lab_values_table"))
     ),
     encoding = shiny::div(
@@ -416,7 +416,7 @@ srv_g_laboratory <- function(id,
         teal.code::eval_code(as.expression(labor_calls))
     })
 
-    output$title <- renderText({
+    output$title <- shiny::renderText({
       paste("<h5><b>Patient ID:", all_q()[["pt_id"]], "</b></h5>")
     })
 

--- a/R/tm_t_pp_laboratory.R
+++ b/R/tm_t_pp_laboratory.R
@@ -214,6 +214,7 @@ ui_g_laboratory <- function(id, ...) {
   ns <- shiny::NS(id)
   teal.widgets::standard_layout(
     output = shiny::div(
+      htmlOutput(ns("title")),
       DT::DTOutput(outputId = ns("lab_values_table"))
     ),
     encoding = shiny::div(
@@ -393,6 +394,7 @@ srv_g_laboratory <- function(id,
         anl_q(),
         substitute(
           expr = {
+            pt_id <- patient_id
             ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
           }, env = list(
             patient_col = patient_col,
@@ -401,6 +403,10 @@ srv_g_laboratory <- function(id,
         )
       ) %>%
         teal.code::eval_code(as.expression(labor_calls))
+    })
+
+    output$title <- renderText({
+      paste("<h5><b>Patient ID:", all_q()[["pt_id"]], "</b></h5>")
     })
 
     table_r <- shiny::reactive({
@@ -437,12 +443,13 @@ srv_g_laboratory <- function(id,
     if (with_reporter) {
       card_fun <- function(comment) {
         card <- teal::TealReportCard$new()
-        card$set_name("Patient Profile Laboratory Table")
-        card$append_text("Patient Profile Laboratory Table", "header2")
+        card$set_name("Patient Profile Laboratory")
+        card$append_text("Patient Profile Laboratory", "header2")
         if (with_filter) {
           card$append_fs(filter_panel_api$get_filter_state())
         }
         card$append_text("Table", "header3")
+        card$append_text(paste("Patient ID:", all_q()[["pt_id"]]), "verbatim")
         card$append_table(table_r()$raw)
         if (!comment == "") {
           card$append_text("Comment", "header3")

--- a/R/tm_t_pp_medical_history.R
+++ b/R/tm_t_pp_medical_history.R
@@ -13,7 +13,7 @@ template_medical_history <- function(dataname = "ANL",
                                      mhterm = "MHTERM",
                                      mhbodsys = "MHBODSYS",
                                      mhdistat = "MHDISTAT",
-                                     patient_id) {
+                                     patient_id = NULL) {
   assertthat::assert_that(
     assertthat::is.string(dataname),
     assertthat::is.string(mhterm),

--- a/R/tm_t_pp_medical_history.R
+++ b/R/tm_t_pp_medical_history.R
@@ -6,12 +6,14 @@
 #' @param mhterm (`character`)\cr name of the reported name for medical history variable.
 #' @param mhbodsys (`character`)\cr name of the body system or organ class variable.
 #' @param mhdistat (`character`)\cr name of the status of the disease variable.
+#' @param patient_id (`character`)\cr patient ID.
 #' @keywords internal
 #'
 template_medical_history <- function(dataname = "ANL",
                                      mhterm = "MHTERM",
                                      mhbodsys = "MHBODSYS",
-                                     mhdistat = "MHDISTAT") {
+                                     mhdistat = "MHDISTAT",
+                                     patient_id) {
   assertthat::assert_that(
     assertthat::is.string(dataname),
     assertthat::is.string(mhterm),
@@ -51,6 +53,8 @@ template_medical_history <- function(dataname = "ANL",
         rtables::analyze_colvars(function(x) x[seq_along(x)]) %>%
         rtables::build_table(result_raw)
 
+      main_title(result) <- paste("Patient ID:", patient_id)
+
       result
     }, env = list(
       dataname = as.name(dataname),
@@ -59,7 +63,8 @@ template_medical_history <- function(dataname = "ANL",
       mhdistat = as.name(mhdistat),
       mhbodsys_char = mhbodsys,
       mhterm_char = mhterm,
-      mhdistat_char = mhdistat
+      mhdistat_char = mhdistat,
+      patient_id = patient_id
     ))
   )
 
@@ -297,7 +302,8 @@ srv_t_medical_history <- function(id,
         dataname = "ANL",
         mhterm = input[[extract_input("mhterm", dataname)]],
         mhbodsys = input[[extract_input("mhbodsys", dataname)]],
-        mhdistat = input[[extract_input("mhdistat", dataname)]]
+        mhdistat = input[[extract_input("mhdistat", dataname)]],
+        patient_id = patient_id()
       )
 
       teal.code::eval_code(

--- a/man/template_basic_info.Rd
+++ b/man/template_basic_info.Rd
@@ -4,13 +4,15 @@
 \alias{template_basic_info}
 \title{Template: Basic Info}
 \usage{
-template_basic_info(dataname = "ANL", vars)
+template_basic_info(dataname = "ANL", vars, patient_id = NULL)
 }
 \arguments{
 \item{dataname}{(\code{character})\cr
 analysis data used in teal module.}
 
 \item{vars}{(\code{character})\cr variable names to be shown in Basic Info tab.}
+
+\item{patient_id}{(\code{character})\cr patient ID.}
 }
 \description{
 Creates a basic info template.

--- a/man/template_laboratory.Rd
+++ b/man/template_laboratory.Rd
@@ -12,6 +12,7 @@ template_laboratory(
   timepoints = "ADY",
   aval = "AVAL",
   avalu = "AVALU",
+  patient_id = NULL,
   round_value = 0L
 )
 }
@@ -31,6 +32,8 @@ the laboratory table.}
 \item{aval}{(\code{character})\cr name of the analysis value variable.}
 
 \item{avalu}{(\code{character})\cr name of the analysis value unit variable.}
+
+\item{patient_id}{(\code{character})\cr patient ID.}
 
 \item{round_value}{(\code{numeric})\cr number of decimal places to be used when rounding.}
 }

--- a/man/template_medical_history.Rd
+++ b/man/template_medical_history.Rd
@@ -8,7 +8,8 @@ template_medical_history(
   dataname = "ANL",
   mhterm = "MHTERM",
   mhbodsys = "MHBODSYS",
-  mhdistat = "MHDISTAT"
+  mhdistat = "MHDISTAT",
+  patient_id = NULL
 )
 }
 \arguments{
@@ -20,6 +21,8 @@ analysis data used in teal module.}
 \item{mhbodsys}{(\code{character})\cr name of the body system or organ class variable.}
 
 \item{mhdistat}{(\code{character})\cr name of the status of the disease variable.}
+
+\item{patient_id}{(\code{character})\cr patient ID.}
 }
 \description{
 Creates medical history template.

--- a/staged_dependencies.yaml
+++ b/staged_dependencies.yaml
@@ -11,6 +11,9 @@ upstream_repos:
   insightsengineering/tern.gee:
     repo: insightsengineering/tern.gee
     host: https://github.com
+  insightsengineering/rlistings:
+    repo: insightsengineering/rlistings
+    host: https://github.com
   insightsengineering/rtables:
     repo: insightsengineering/rtables
     host: https://github.com

--- a/tests/testthat/_snaps/tm_t_pp_medical_history.md
+++ b/tests/testthat/_snaps/tm_t_pp_medical_history.md
@@ -16,6 +16,7 @@
               rtables::split_rows_by(colnames(result_raw)[2], split_fun = rtables::drop_split_levels, 
                   child_labels = "hidden") %>% rtables::analyze_colvars(function(x) x[seq_along(x)]) %>% 
               rtables::build_table(result_raw)
+          main_title(result) <- paste("Patient ID:", NULL)
           result
       }
 


### PR DESCRIPTION
Closes #816 

Last commit implements `rlistings` - without this we can only do a workaround as titles can't be directly implemented in regular data frames.

Note: If we use the `rlistings` package we will also need to update staged.dependencies in `rlistings`.