### PR TITLE
`tdata`  to  `teal_data` - `tm_t_smq`

### DIFF
--- a/R/tm_t_smq.R
+++ b/R/tm_t_smq.R
@@ -539,7 +539,8 @@ srv_t_smq <- function(id,
                       basic_table_args) {
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
-  checkmate::assert_class(data, "tdata")
+  checkmate::assert_class(data, "reactive")
+  checkmate::assert_class(isolate(data()), "teal_data")
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(
       data_extract = list(
@@ -570,19 +571,17 @@ srv_t_smq <- function(id,
     anl_inputs <- teal.transform::merge_expression_srv(
       datasets = data,
       selector_list = selector_list,
-      join_keys = teal.data::join_keys(data),
       merge_function = "dplyr::inner_join"
     )
 
     adsl_inputs <- teal.transform::merge_expression_module(
       datasets = data,
-      join_keys = teal.data::join_keys(data),
       data_extract = list(arm_var = arm_var),
       anl_name = "ANL_ADSL"
     )
 
     anl_q <- shiny::reactive({
-      teal.code::new_qenv(tdata2env(data), code = get_code_tdata(data)) %>%
+      data() %>%
         teal.code::eval_code(as.expression(anl_inputs()$expr)) %>%
         teal.code::eval_code(as.expression(adsl_inputs()$expr))
     })


### PR DESCRIPTION
**Example App**

```
data <- teal_data()
data <- within(data, {
  ADSL <- tmc_ex_adsl
  ADAE <- tmc_ex_adae

  names_baskets <- grep("^(SMQ|CQ).*NAM$", names(ADAE), value = TRUE)
  names_scopes <- grep("^SMQ.*SC$", names(ADAE), value = TRUE)

  cs_baskets <- choices_selected(
    choices = variable_choices(ADAE, subset = names_baskets),
    selected = names_baskets
  )

  cs_scopes <- choices_selected(
    choices = variable_choices(ADAE, subset = names_scopes),
    selected = names_scopes,
    fixed = TRUE
  )
})

datanames <- c("ADSL", "ADAE")
datanames(data) <- datanames
join_keys(data) <- default_cdisc_join_keys[datanames]

app <- init(
  data = data,
  modules = modules(
    tm_t_smq(
      label = "Adverse Events by SMQ Table",
      dataname = "ADAE",
      arm_var = choices_selected(
        choices = variable_choices(data[["ADSL"]], subset = c("ARM", "SEX")),
        selected = "ARM"
      ),
      add_total = FALSE,
      baskets = data[["cs_baskets"]],
      scopes = data[["cs_scopes"]],
      llt = choices_selected(
        choices = variable_choices(data[["ADAE"]], subset = c("AEDECOD")),
        selected = "AEDECOD"
      )
    )
  )
)

shinyApp(app$ui, app$server)
```
