### PR TITLE
fix missing prefixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,7 +69,6 @@ Suggests:
     knitr,
     lubridate,
     nestcolor (>= 0.1.0),
-    teal.data (>= 0.3.0.9010),
     testthat (>= 3.0)
 VignetteBuilder:
     knitr

--- a/R/tm_a_gee.R
+++ b/R/tm_a_gee.R
@@ -370,7 +370,7 @@ srv_gee <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     ## split_covariates ----
@@ -402,7 +402,7 @@ srv_gee <- function(id,
       input,
       output,
       id_arm_var = extract_input("arm_var", parentname),
-      data = reactive(data()[[parentname]]),
+      data = shiny::reactive(data()[[parentname]]),
       arm_ref_comp = arm_ref_comp,
       module = "tm_a_gee"
     )

--- a/R/tm_a_mmrm.R
+++ b/R/tm_a_mmrm.R
@@ -825,7 +825,7 @@ srv_mmrm <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     # Reactive responsible for sending a disable/enable signal
@@ -854,7 +854,7 @@ srv_mmrm <- function(id,
       input,
       output,
       id_arm_var = extract_input("arm_var", parentname), # From UI.
-      data = reactive(data()[[parentname]]),
+      data = shiny::reactive(data()[[parentname]]),
       arm_ref_comp = arm_ref_comp,
       module = "tm_mmrm"
     )

--- a/R/tm_g_barchart_simple.R
+++ b/R/tm_g_barchart_simple.R
@@ -330,7 +330,7 @@ srv_g_barchart_simple <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     rule_dupl <- function(others) {
@@ -409,7 +409,7 @@ srv_g_barchart_simple <- function(id,
         count_exprs <- c(count_exprs, count_exprs2, count_str_to_col_exprs)
       }
 
-      data_list <- sapply(teal.data::datanames(data()), function(x) reactive(data()[[x]]),
+      data_list <- sapply(teal.data::datanames(data()), function(x) shiny::reactive(data()[[x]]),
         simplify = FALSE
       )
 

--- a/R/tm_g_ci.R
+++ b/R/tm_g_ci.R
@@ -377,7 +377,7 @@ srv_g_ci <- function(id, # nolint
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(

--- a/R/tm_t_abnormality.R
+++ b/R/tm_t_abnormality.R
@@ -498,7 +498,7 @@ srv_t_abnormality <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(

--- a/R/tm_t_abnormality_by_worst_grade.R
+++ b/R/tm_t_abnormality_by_worst_grade.R
@@ -499,7 +499,7 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(

--- a/R/tm_t_events.R
+++ b/R/tm_t_events.R
@@ -644,7 +644,7 @@ srv_t_events_byterm <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(

--- a/R/tm_t_events_by_grade.R
+++ b/R/tm_t_events_by_grade.R
@@ -998,7 +998,7 @@ srv_t_events_by_grade <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(

--- a/R/tm_t_events_patyear.R
+++ b/R/tm_t_events_patyear.R
@@ -387,7 +387,7 @@ srv_events_patyear <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     shiny::observeEvent(anl_q(), {

--- a/R/tm_t_events_summary.R
+++ b/R/tm_t_events_summary.R
@@ -789,7 +789,7 @@ srv_t_events_summary <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     data_extract_vars <- list(

--- a/R/tm_t_exposure.R
+++ b/R/tm_t_exposure.R
@@ -478,7 +478,7 @@ srv_t_exposure <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
   shiny::moduleServer(id, function(input, output, session) {
     rule_intersection <- function(other) {
       function(value) {

--- a/R/tm_t_logistic.R
+++ b/R/tm_t_logistic.R
@@ -455,7 +455,7 @@ srv_t_logistic <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     # Observer to update reference and comparison arm input options.
@@ -464,7 +464,7 @@ srv_t_logistic <- function(id,
       input,
       output,
       id_arm_var = extract_input("arm_var", parentname),
-      data = reactive(data()[[parentname]]),
+      data = shiny::reactive(data()[[parentname]]),
       arm_ref_comp = arm_ref_comp,
       module = "tm_t_logistic"
     )

--- a/R/tm_t_mult_events.R
+++ b/R/tm_t_mult_events.R
@@ -463,7 +463,7 @@ srv_t_mult_events_byterm <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(

--- a/R/tm_t_pp_basic_info.R
+++ b/R/tm_t_pp_basic_info.R
@@ -173,7 +173,7 @@ srv_t_basic_info <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     patient_id <- shiny::reactive(input$patient_id)

--- a/R/tm_t_pp_laboratory.R
+++ b/R/tm_t_pp_laboratory.R
@@ -311,7 +311,7 @@ srv_g_laboratory <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     patient_id <- shiny::reactive(input$patient_id)
@@ -342,7 +342,7 @@ srv_g_laboratory <- function(id,
     )
 
     # Update round_values
-    aval_values <- isolate(data())[[dataname]][, aval$select$selected]
+    aval_values <- shiny::isolate(data())[[dataname]][, aval$select$selected]
     decimal_nums <- aval_values[trunc(aval_values) != aval_values]
     max_decimal <- max(nchar(gsub("([0-9]+).([0-9]+)", "\\2", decimal_nums)))
 

--- a/R/tm_t_pp_medical_history.R
+++ b/R/tm_t_pp_medical_history.R
@@ -236,7 +236,7 @@ srv_t_medical_history <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     patient_id <- shiny::reactive(input$patient_id)

--- a/R/tm_t_pp_prior_medication.R
+++ b/R/tm_t_pp_prior_medication.R
@@ -242,7 +242,7 @@ srv_t_prior_medication <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     patient_id <- shiny::reactive(input$patient_id)

--- a/R/tm_t_shift_by_arm.R
+++ b/R/tm_t_shift_by_arm.R
@@ -396,7 +396,7 @@ srv_shift_by_arm <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(
       data_extract = list(

--- a/R/tm_t_shift_by_arm_by_worst.R
+++ b/R/tm_t_shift_by_arm_by_worst.R
@@ -419,7 +419,7 @@ srv_shift_by_arm_by_worst <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(
       data_extract = list(

--- a/R/tm_t_shift_by_grade.R
+++ b/R/tm_t_shift_by_grade.R
@@ -754,7 +754,7 @@ srv_t_shift_by_grade <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(

--- a/R/tm_t_smq.R
+++ b/R/tm_t_smq.R
@@ -540,7 +540,7 @@ srv_t_smq <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(
       data_extract = list(

--- a/R/tm_t_summary.R
+++ b/R/tm_t_summary.R
@@ -432,7 +432,7 @@ srv_summary <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
   shiny::moduleServer(id, function(input, output, session) {
     selector_list <- teal.transform::data_extract_multiple_srv(
       data_extract = list(arm_var = arm_var, summarize_vars = summarize_vars),

--- a/R/tm_t_summary_by.R
+++ b/R/tm_t_summary_by.R
@@ -600,7 +600,7 @@ srv_summary_by <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
     vars <- list(arm_var = arm_var, id_var = id_var, summarize_vars = summarize_vars, by_vars = by_vars)

--- a/R/tm_t_tte.R
+++ b/R/tm_t_tte.R
@@ -723,7 +723,7 @@ srv_t_tte <- function(id,
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
-  checkmate::assert_class(isolate(data()), "teal_data")
+  checkmate::assert_class(shiny::isolate(data()), "teal_data")
   shiny::moduleServer(id, function(input, output, session) {
     # Setup arm variable selection, default reference arms, and default
     # comparison arms for encoding panel
@@ -732,7 +732,7 @@ srv_t_tte <- function(id,
       input,
       output,
       id_arm_var = extract_input("arm_var", parentname),
-      data = reactive(data()[[parentname]]),
+      data = shiny::reactive(data()[[parentname]]),
       arm_ref_comp = arm_ref_comp,
       module = "tm_t_tte",
       on_off = shiny::reactive(input$compare_arms)


### PR DESCRIPTION
Added `shiny::` to `isolate` and `reactive` calls.
Removed duplicate dependency on `teal_data`.