### PR TITLE
fix `tm_g_pp_vitals`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,7 +69,6 @@ Suggests:
     knitr,
     lubridate,
     nestcolor (>= 0.1.0),
-    teal.data (>= 0.3.0.9010),
     testthat (>= 3.0)
 VignetteBuilder:
     knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# teal.modules.clinical 0.8.16.9011
+# teal.modules.clinical 0.8.16.9012
 
 ### Enhancements
 * Updated the documentation and vignettes to demonstrate method to pass `teal_data` object to `teal::init()`.

--- a/R/tm_g_pp_vitals.R
+++ b/R/tm_g_pp_vitals.R
@@ -64,108 +64,116 @@ template_vitals <- function(dataname = "ANL",
 
   vital_plot <- add_expr(
     list(),
-    substitute(expr = {
-      vitals <-
-        dataname %>%
-        dplyr::group_by(paramcd, xaxis) %>%
-        dplyr::filter(paramcd %in% paramcd_levels_chars) %>%
-        dplyr::summarise(AVAL = max(aval, na.rm = TRUE)) %>%
-        dplyr::mutate(AVAL = ifelse(is.infinite(AVAL), NA, AVAL))
+    substitute_names(
+      expr = {
+        vitals <-
+          dataname %>%
+          dplyr::group_by(paramcd, xaxis) %>%
+          dplyr::filter(paramcd %in% paramcd_levels_chars) %>%
+          dplyr::summarise(aval = max(aval, na.rm = TRUE)) %>%
+          dplyr::mutate(
+            aval = ifelse(is.infinite(aval), NA, aval),
+            xaxis = as.numeric(xaxis) # difftime fails ggplot2::scale_x_continuous
+          )
 
-      max_day <- max(vitals[[xaxis_char]], na.rm = TRUE)
-      max_aval <- max(vitals[[aval_char]], na.rm = TRUE)
-      max_aval_seq <- seq(0, max_aval, 10)
+        max_day <- max(vitals[[xaxis_char]], na.rm = TRUE)
+        max_aval <- max(vitals[[aval_char]], na.rm = TRUE)
+        max_aval_seq <- seq(0, max_aval, 10)
 
-      full_vita <- levels(dataname[[paramcd_char]])
-      provided_vita <- paramcd_levels_chars
-      known_vita <- c("SYSBP", "DIABP", "TEMP", "RESP", "OXYSAT", "PULSE")
+        full_vita <- levels(dataname[[paramcd_char]])
+        provided_vita <- paramcd_levels_chars
+        known_vita <- c("SYSBP", "DIABP", "TEMP", "RESP", "OXYSAT", "PULSE")
 
-      paramcd_levels_e <- known_vita[stats::na.omit(match(provided_vita, known_vita))]
-      len_paramcd_levels_e <- length(paramcd_levels_e)
+        paramcd_levels_e <- known_vita[stats::na.omit(match(provided_vita, known_vita))]
+        len_paramcd_levels_e <- length(paramcd_levels_e)
 
-      all_colors <- stats::setNames(nestcolor::color_palette(length(full_vita), "stream"), full_vita)
-      vars_colors <- all_colors[provided_vita]
-      names(vars_colors) <- provided_vita
+        all_colors <- stats::setNames(nestcolor::color_palette(length(full_vita), "stream"), full_vita)
+        vars_colors <- all_colors[provided_vita]
+        names(vars_colors) <- provided_vita
 
-      base_stats <- stats::setNames(c(140, 90, 38, 20, 94, 100), known_vita)
-      paramcd_stats_e <- base_stats[paramcd_levels_e]
+        base_stats <- stats::setNames(c(140, 90, 38, 20, 94, 100), known_vita)
+        paramcd_stats_e <- base_stats[paramcd_levels_e]
 
-      base_labels <- stats::setNames(c("140mmHg", "90mmHg", "38\u00B0 C", "20/min", "94%", "100bpm"), known_vita)
-      paramcd_labels_e <- base_labels[paramcd_levels_e]
+        base_labels <- stats::setNames(c("140mmHg", "90mmHg", "38\u00B0 C", "20/min", "94%", "100bpm"), known_vita)
+        paramcd_labels_e <- base_labels[paramcd_levels_e]
 
-      base_stats_df <- data.frame(
-        x = rep(1, len_paramcd_levels_e),
-        y = paramcd_stats_e,
-        label = paramcd_labels_e,
-        color = paramcd_levels_e
+        base_stats_df <- data.frame(
+          x = rep(1, len_paramcd_levels_e),
+          y = paramcd_stats_e,
+          label = paramcd_labels_e,
+          color = paramcd_levels_e
+        )
+
+        result_plot <- ggplot2::ggplot(data = vitals, mapping = ggplot2::aes(x = xaxis)) + # replaced VSDY
+          ggplot2::geom_line(
+            data = vitals,
+            mapping = ggplot2::aes(y = aval, color = paramcd),
+            size = 1.5,
+            alpha = 0.5
+          ) +
+          ggplot2::scale_color_manual(
+            values = vars_colors
+          ) +
+          ggplot2::geom_text(
+            data = base_stats_df,
+            ggplot2::aes(x = x, y = y, label = label, color = color),
+            alpha = 1,
+            nudge_y = 2.2,
+            size = font_size_var / 3.5,
+            show.legend = FALSE
+          ) +
+          ggplot2::geom_hline(
+            data = base_stats_df,
+            ggplot2::aes(yintercept = y, color = color),
+            linetype = 2,
+            alpha = 0.5,
+            size = 1,
+            show.legend = FALSE
+          ) +
+          ggplot2::scale_y_continuous(
+            breaks = seq(0, max(vitals[[xaxis_char]], na.rm = TRUE), 50),
+            minor_breaks = seq(0, max(vitals[[aval_char]], na.rm = TRUE), 10)
+          ) +
+          ggplot2::geom_text(
+            data = data.frame(
+              x = rep(max_day, length(max_aval_seq)),
+              y = max_aval_seq,
+              l = as.character(max_aval_seq)
+            ),
+            ggplot2::aes(
+              x = x,
+              y = y,
+              label = l
+            ),
+            color = "black",
+            alpha = 1,
+            nudge_y = 2.2,
+            size = font_size_var / 3.5
+          ) +
+          labs +
+          ggthemes +
+          themes
+
+        print(result_plot)
+      },
+      names = list(
+        dataname = as.name(dataname),
+        paramcd = as.name(paramcd),
+        xaxis = as.name(xaxis),
+        aval = as.name(aval)
+      ),
+      others = list(
+        paramcd_char = paramcd,
+        paramcd_levels_chars = paramcd_levels,
+        xaxis_char = xaxis,
+        aval_char = aval,
+        patient_id = patient_id,
+        font_size_var = font_size,
+        labs = parsed_ggplot2_args$labs,
+        ggthemes = parsed_ggplot2_args$ggtheme,
+        themes = parsed_ggplot2_args$theme
       )
-
-      result_plot <- ggplot2::ggplot(data = vitals, mapping = ggplot2::aes(x = xaxis)) + # replaced VSDY
-        ggplot2::geom_line(
-          data = vitals,
-          mapping = ggplot2::aes(y = aval, color = paramcd),
-          size = 1.5,
-          alpha = 0.5
-        ) +
-        ggplot2::scale_color_manual(
-          values = vars_colors,
-        ) +
-        ggplot2::geom_text(
-          data = base_stats_df,
-          ggplot2::aes(x = x, y = y, label = label, color = color),
-          alpha = 1,
-          nudge_y = 2.2,
-          size = font_size_var / 3.5,
-          show.legend = FALSE
-        ) +
-        ggplot2::geom_hline(
-          data = base_stats_df,
-          ggplot2::aes(yintercept = y, color = color),
-          linetype = 2,
-          alpha = 0.5,
-          size = 1,
-          show.legend = FALSE
-        ) +
-        ggplot2::scale_y_continuous(
-          breaks = seq(0, max(vitals[[xaxis_char]], na.rm = TRUE), 50),
-          minor_breaks = seq(0, max(vitals[[aval_char]], na.rm = TRUE), 10)
-        ) +
-        ggplot2::geom_text(
-          data = data.frame(
-            x = rep(max_day, length(max_aval_seq)),
-            y = max_aval_seq,
-            l = as.character(max_aval_seq)
-          ),
-          ggplot2::aes(
-            x = x,
-            y = y,
-            label = l
-          ),
-          color = "black",
-          alpha = 1,
-          nudge_y = 2.2,
-          size = font_size_var / 3.5
-        ) +
-        labs +
-        ggthemes +
-        themes
-
-      print(result_plot)
-    }, env = list(
-      dataname = as.name(dataname),
-      paramcd = as.name(paramcd),
-      paramcd_char = paramcd,
-      paramcd_levels_chars = paramcd_levels,
-      xaxis = as.name(xaxis),
-      xaxis_char = xaxis,
-      aval = as.name(aval),
-      aval_char = aval,
-      patient_id = patient_id,
-      font_size_var = font_size,
-      labs = parsed_ggplot2_args$labs,
-      ggthemes = parsed_ggplot2_args$ggtheme,
-      themes = parsed_ggplot2_args$theme
-    ))
+    )
   )
 
   y$plot <- bracket_expr(vital_plot)

--- a/R/tm_g_pp_vitals.R
+++ b/R/tm_g_pp_vitals.R
@@ -65,23 +65,37 @@ template_vitals <- function(dataname = "ANL",
   vital_plot <- add_expr(
     list(),
     substitute_names(
+      names = list(
+        dataname = as.name(dataname),
+        paramcd = as.name(paramcd),
+        xaxis = as.name(xaxis),
+        aval = as.name(aval)
+      ),
+      others = list(paramcd_levels = paramcd_levels),
       expr = {
         vitals <-
           dataname %>%
           dplyr::group_by(paramcd, xaxis) %>%
-          dplyr::filter(paramcd %in% paramcd_levels_chars) %>%
+          dplyr::filter(paramcd %in% paramcd_levels) %>%
           dplyr::summarise(aval = max(aval, na.rm = TRUE)) %>%
           dplyr::mutate(
             aval = ifelse(is.infinite(aval), NA, aval),
             xaxis = as.numeric(xaxis) # difftime fails ggplot2::scale_x_continuous
           )
+      }
+    )
+  )
 
+  vital_plot <- add_expr(
+    vital_plot,
+    substitute(
+      expr = {
         max_day <- max(vitals[[xaxis_char]], na.rm = TRUE)
         max_aval <- max(vitals[[aval_char]], na.rm = TRUE)
         max_aval_seq <- seq(0, max_aval, 10)
 
         full_vita <- levels(dataname[[paramcd_char]])
-        provided_vita <- paramcd_levels_chars
+        provided_vita <- paramcd_levels
         known_vita <- c("SYSBP", "DIABP", "TEMP", "RESP", "OXYSAT", "PULSE")
 
         paramcd_levels_e <- known_vita[stats::na.omit(match(provided_vita, known_vita))]
@@ -156,16 +170,14 @@ template_vitals <- function(dataname = "ANL",
 
         print(result_plot)
       },
-      names = list(
+      env = list(
         dataname = as.name(dataname),
         paramcd = as.name(paramcd),
-        xaxis = as.name(xaxis),
-        aval = as.name(aval)
-      ),
-      others = list(
         paramcd_char = paramcd,
-        paramcd_levels_chars = paramcd_levels,
+        paramcd_levels = paramcd_levels,
+        xaxis = as.name(xaxis),
         xaxis_char = xaxis,
+        aval = as.name(aval),
         aval_char = aval,
         patient_id = patient_id,
         font_size_var = font_size,


### PR DESCRIPTION
closes #895 

Error thrown in `qenv` is caused by following line 
```r
          ggplot2::scale_y_continuous(
            breaks = seq(0, max(vitals[[xaxis_char]], na.rm = TRUE), 50),
            minor_breaks = seq(0, max(vitals[[aval_char]], na.rm = TRUE), 10)
          )
```

Problem with this line is that `vitals[[xaxis_char]]` in our example is a `difftime` (column "ADY"). 
`x` as `difftime` causes also warning in the first line of ggplot call (`ggplot2::ggplot(data = vitals, mapping = ggplot2::aes(x = xaxis))`) so I decided to include conversion to integer in `mutate`. More in comments.