### PR TITLE
Change r.pkg.template branch to main

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,7 +21,7 @@ jobs:
     uses: insightsengineering/r.pkg.template/.github/workflows/audit.yaml@main
   r-cmd:
     name: R CMD Check 🧬
-    uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@install-tern-from-cran
+    uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
@@ -51,7 +51,7 @@ jobs:
     uses: insightsengineering/r.pkg.template/.github/workflows/linter.yaml@main
   roxygen:
     name: Roxygen 🅾
-    uses: insightsengineering/r.pkg.template/.github/workflows/roxygen.yaml@install-tern-from-cran
+    uses: insightsengineering/r.pkg.template/.github/workflows/roxygen.yaml@main
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -36,7 +36,7 @@ on:
 jobs:
   docs:
     name: Pkgdown Docs 📚
-    uses: insightsengineering/r.pkg.template/.github/workflows/pkgdown.yaml@install-tern-from-cran
+    uses: insightsengineering/r.pkg.template/.github/workflows/pkgdown.yaml@main
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:


### PR DESCRIPTION
Since `teal.modules.clinical` now again [`Depends` on `tern >= 0.9.3`](https://github.com/insightsengineering/teal.modules.clinical/blob/bd513f0c33b81b5c98c0b366c564823068b1737c/DESCRIPTION#L31), I think we can change the workflow branch back from `install-tern-from-cran` to `main` (changed in https://github.com/insightsengineering/teal.modules.clinical/pull/922).