### PR TITLE
Allow `NULL` `paramcd` value in `tm_t_summary_by`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # teal.modules.clinical 0.9.0.9001
 
+### Enhancements
+* Updated `tm_t_summary_by` to allow `NULL` input to `paramcd` argument.
+
 ### Miscellaneous
 * Removed `formatters` from dependencies and replaced the use of its functions relating to variable labels with functions from `teal.data`.
 

--- a/R/tm_t_summary_by.R
+++ b/R/tm_t_summary_by.R
@@ -402,7 +402,7 @@ tm_t_summary_by <- function(label,
   checkmate::assert_class(by_vars, "choices_selected")
   checkmate::assert_class(summarize_vars, "choices_selected")
   checkmate::assert_class(id_var, "choices_selected")
-  checkmate::assert_class(paramcd, "choices_selected")
+  checkmate::assert_class(paramcd, "choices_selected", null.ok = TRUE)
   checkmate::assert_class(denominator, "choices_selected")
   checkmate::assert_flag(add_total)
   checkmate::assert_string(total_label)


### PR DESCRIPTION
# Pull Request

<!--- Replace `#nnn` with your issue link for reference. -->

Fixes #1082

Required version of `teal.data` should be updated after merging https://github.com/insightsengineering/teal.data/pull/301.
