### PR TITLE
Cleanup of `# nolint` comments

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -2,5 +2,8 @@ linters: linters_with_defaults(
   line_length_linter = line_length_linter(120),
   cyclocomp_linter = NULL,
   object_usage_linter = NULL,
-  indentation_linter = NULL
+  object_name_linter = object_name_linter(
+    styles = c("snake_case", "symbols"),
+    regexes = c(ANL = "^ANL_?[0-9A-Z_]*$", ADaM = "^r?AD[A-Z]{2,3}_?[0-9]*$")
+  )
   )

--- a/R/string_ops.R
+++ b/R/string_ops.R
@@ -22,20 +22,19 @@
 #' )
 #' lapply(dta, as_num)
 #' @export
-as_num <- function(str) { # nolint # nousage
+as_num <- function(str) {
   UseMethod("as_num")
 }
 
 #' @export
 #' @rdname as_num
-as_num.default <- function(str) { # nolint # nousage
+as_num.default <- function(str) {
   stop("No default implementation for `as_num.default`.")
 }
 
 #' @export
 #' @rdname as_num
-as_num.character <- function(str) { # nolint # nousage
-
+as_num.character <- function(str) {
   y <- regmatches(
     x = str,
     m = gregexpr(
@@ -53,13 +52,13 @@ as_num.character <- function(str) { # nolint # nousage
 
 #' @export
 #' @rdname as_num
-as_num.numeric <- function(str) { # nolint # nousage
+as_num.numeric <- function(str) {
   return(str)
 }
 
 #' @export
 #' @rdname as_num
-as_num.factor <- function(str) { # nolint # nousage
+as_num.factor <- function(str) {
   y <- as.character(str)
   y <- as_num(y)
   return(y)
@@ -67,7 +66,7 @@ as_num.factor <- function(str) { # nolint # nousage
 
 #' @export
 #' @rdname as_num
-as_num.logical <- function(str) { # nolint # nousage
+as_num.logical <- function(str) {
   y <- as.numeric(str)
   return(y)
 }

--- a/R/tm_a_mmrm.R
+++ b/R/tm_a_mmrm.R
@@ -1120,7 +1120,7 @@ srv_mmrm <- function(id,
     state_has_changed <- shiny::reactive({
       shiny::req(state$input)
       displayed_state <- mmrm_inputs_reactive()
-      equal_ADSL <- all.equal(state$input$adsl_filtered, displayed_state$adsl_filtered) # nolint
+      equal_ADSL <- all.equal(state$input$adsl_filtered, displayed_state$adsl_filtered) # nolint: object_name.
       equal_dataname <- all.equal(state$input$anl_filtered, displayed_state$anl_filtered)
       true_means_change <- vapply(
         sync_inputs,
@@ -1292,8 +1292,8 @@ srv_mmrm <- function(id,
 
       anl_m_inputs <- anl_inputs()
 
-      ANL <- qenv[["ANL"]] # nolint
-      ANL_ADSL <- qenv[["ANL_ADSL"]] # nolint
+      ANL <- qenv[["ANL"]]
+      ANL_ADSL <- qenv[["ANL_ADSL"]]
       paramcd <- unique(ANL[[unlist(paramcd$filter)["vars_selected"]]])
 
       basic_table_args$subtitles <- paste0(

--- a/R/tm_g_barchart_simple.R
+++ b/R/tm_g_barchart_simple.R
@@ -488,7 +488,7 @@ srv_g_barchart_simple <- function(id,
         ggplot2_args = all_ggplot2_args
       )
 
-      ANL <- count_q()[["ANL"]] # nolint
+      ANL <- count_q()[["ANL"]]
 
       all_q <- count_q() %>%
         teal.code::eval_code(substitute(
@@ -689,11 +689,11 @@ make_barchart_simple_call <- function(y_name,
     # center text and move slightly to the top or to the right (depending on flip axes)
     # see https://stackoverflow.com/questions/7263849/what-do-hjust-and-vjust-do-when-making-a-plot-using-ggplot
     if (isTRUE(flip_axis)) {
-      hjust <- if (barlayout == "stacked") 0.5 else -1 # put above bars if not stacked # nolint
+      hjust <- if (barlayout == "stacked") 0.5 else -1 # put above bars if not stacked
       vjust <- 0.5
     } else {
       hjust <- 0.5
-      vjust <- if (barlayout == "stacked") 0.5 else -1 # put above bars if not stacked # nolint
+      vjust <- if (barlayout == "stacked") 0.5 else -1 # put above bars if not stacked
     }
 
     plot_args <- c(plot_args, bquote(

--- a/R/tm_g_ipp.R
+++ b/R/tm_g_ipp.R
@@ -574,7 +574,7 @@ srv_g_ipp <- function(id,
       validate_checks()
       anl_m <- anl_inputs()
 
-      ANL <- anl_q()[["ANL"]] # nolint
+      ANL <- anl_q()[["ANL"]]
       teal::validate_has_data(ANL, 2)
 
       arm_var <- unlist(arm_var$filter)["vars_selected"]

--- a/R/tm_g_km.R
+++ b/R/tm_g_km.R
@@ -480,7 +480,7 @@ ui_g_km <- function(id, ...) {
               label = shiny::HTML(
                 paste(
                   "p-value method for ",
-                  shiny::span(class = "text-primary", "Coxph"), # nolint
+                  shiny::span(class = "text-primary", "Coxph"),
                   " (Hazard Ratio)",
                   sep = ""
                 )
@@ -493,7 +493,7 @@ ui_g_km <- function(id, ...) {
               label = shiny::HTML(
                 paste(
                   "Ties for ",
-                  shiny::span(class = "text-primary", "Coxph"), # nolint
+                  shiny::span(class = "text-primary", "Coxph"),
                   " (Hazard Ratio)",
                   sep = ""
                 )
@@ -711,7 +711,7 @@ srv_g_km <- function(id,
 
       anl_m <- anl_inputs()
 
-      anl <- anl_q()[["ANL"]] # nolint
+      anl <- anl_q()[["ANL"]]
       teal::validate_has_data(anl, 2)
 
       input_xticks <- if (!is.null(input$xticks)) {

--- a/R/tm_g_lineplot.R
+++ b/R/tm_g_lineplot.R
@@ -589,7 +589,7 @@ srv_g_lineplot <- function(id,
 
     all_q <- shiny::reactive({
       validate_checks()
-      ANL <- merged$anl_q()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]]
       teal::validate_has_data(ANL, 2)
 
       whiskers_selected <- if ("Lower" %in% input$whiskers) 1 else NULL

--- a/R/tm_g_pp_adverse_events.R
+++ b/R/tm_g_pp_adverse_events.R
@@ -516,7 +516,7 @@ srv_g_adverse_events <- function(id,
       teal::validate_inputs(iv_r())
       anl_m <- anl_inputs()
 
-      ANL <- anl_q()[["ANL"]] # nolint
+      ANL <- anl_q()[["ANL"]]
 
       teal::validate_has_data(ANL[ANL[[patient_col]] == input$patient_id, ], min_nrow = 1)
 
@@ -525,7 +525,7 @@ srv_g_adverse_events <- function(id,
         substitute(
           expr = {
             pt_id <- patient_id
-            ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
+            ANL <- ANL[ANL[[patient_col]] == patient_id, ]
           }, env = list(
             patient_col = patient_col,
             patient_id = patient_id()

--- a/R/tm_g_pp_patient_timeline.R
+++ b/R/tm_g_pp_patient_timeline.R
@@ -825,8 +825,10 @@ srv_g_patient_timeline <- function(id,
       shiny::validate(
         shiny::need(
           input$relday_x_axis ||
-            (sum(stats::complete.cases(p_time_data_pat[, c(aetime_start, aetime_end)])) > 0 ||
-              sum(stats::complete.cases(p_time_data_pat[, c(dstime_start, dstime_end)])) > 0),
+            (
+              sum(stats::complete.cases(p_time_data_pat[, c(aetime_start, aetime_end)])) > 0 ||
+                sum(stats::complete.cases(p_time_data_pat[, c(dstime_start, dstime_end)])) > 0
+            ),
           "Selected patient is not in dataset (either due to filtering or missing values). Consider relaxing filters."
         )
       )
@@ -890,7 +892,7 @@ srv_g_patient_timeline <- function(id,
         anl_q(),
         substitute(
           expr = {
-            ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
+            ANL <- ANL[ANL[[patient_col]] == patient_id, ]
           }, env = list(
             patient_col = patient_col,
             patient_id = patient_id()

--- a/R/tm_g_pp_therapy.R
+++ b/R/tm_g_pp_therapy.R
@@ -659,7 +659,7 @@ srv_g_therapy <- function(id,
         substitute(
           expr = {
             pt_id <- patient_id
-            ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
+            ANL <- ANL[ANL[[patient_col]] == patient_id, ]
           }, env = list(
             patient_col = patient_col,
             patient_id = patient_id()

--- a/R/tm_g_pp_vitals.R
+++ b/R/tm_g_pp_vitals.R
@@ -538,7 +538,7 @@ srv_g_vitals <- function(id,
         merged$anl_q(),
         substitute(
           expr = {
-            ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
+            ANL <- ANL[ANL[[patient_col]] == patient_id, ]
           }, env = list(
             patient_col = patient_col,
             patient_id = patient_id()

--- a/R/tm_t_abnormality_by_worst_grade.R
+++ b/R/tm_t_abnormality_by_worst_grade.R
@@ -15,7 +15,7 @@
 #'
 #' @seealso [tm_t_abnormality_by_worst_grade()]
 #' @keywords internal
-template_abnormality_by_worst_grade <- function(parentname, # nolint
+template_abnormality_by_worst_grade <- function(parentname, # nolint: object_length.
                                                 dataname,
                                                 arm_var,
                                                 id_var = "USUBJID",
@@ -291,7 +291,7 @@ template_abnormality_by_worst_grade <- function(parentname, # nolint
 #'   shinyApp(app$ui, app$server)
 #' }
 #'
-tm_t_abnormality_by_worst_grade <- function(label, # nolint
+tm_t_abnormality_by_worst_grade <- function(label, # nolint: object_length.
                                             dataname,
                                             parentname = ifelse(
                                               inherits(arm_var, "data_extract_spec"),
@@ -383,7 +383,7 @@ tm_t_abnormality_by_worst_grade <- function(label, # nolint
 }
 
 #' @keywords internal
-ui_t_abnormality_by_worst_grade <- function(id, ...) { # nolint
+ui_t_abnormality_by_worst_grade <- function(id, ...) { # nolint: object_length.
 
   ns <- shiny::NS(id)
   a <- list(...) # module args
@@ -480,7 +480,7 @@ ui_t_abnormality_by_worst_grade <- function(id, ...) { # nolint
 }
 
 #' @keywords internal
-srv_t_abnormality_by_worst_grade <- function(id, # nolint
+srv_t_abnormality_by_worst_grade <- function(id, # nolint: object_length.
                                              data,
                                              reporter,
                                              filter_panel_api,

--- a/R/tm_t_ancova.R
+++ b/R/tm_t_ancova.R
@@ -844,7 +844,7 @@ srv_ancova <- function(id,
         "ANCOVA table cannot be calculated as all values are missing."
       ))
       # check that for each visit there is at least one record with no missing data
-      all_NA_dataset <- merged$anl_q()[["ANL"]] %>% # nolint
+      all_NA_dataset <- merged$anl_q()[["ANL"]] %>% # nolint: object_name.
         dplyr::group_by(dplyr::across(dplyr::all_of(c(input_avisit, input_arm_var)))) %>%
         dplyr::summarize(all_NA = all(is.na(.data[[input_aval_var]])))
       shiny::validate(shiny::need(
@@ -888,7 +888,7 @@ srv_ancova <- function(id,
     # The R-code corresponding to the analysis.
     table_q <- shiny::reactive({
       validate_checks()
-      ANL <- merged$anl_q()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]]
 
       label_paramcd <- get_paramcd_label(ANL, paramcd)
       input_aval <- as.vector(merged$anl_input_r()$columns_source$aval_var)

--- a/R/tm_t_coxreg.R
+++ b/R/tm_t_coxreg.R
@@ -1001,7 +1001,7 @@ srv_t_coxreg <- function(id,
     all_q <- shiny::reactive({
       validate_checks()
 
-      ANL <- merged$anl_q()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]]
       paramcd <- as.character(unique(ANL[[unlist(paramcd$filter)["vars_selected"]]]))
       multivariate <- input$type == "Multivariate"
       strata_var <- as.vector(merged$anl_input_r()$columns_source$strata_var)

--- a/R/tm_t_events.R
+++ b/R/tm_t_events.R
@@ -772,7 +772,7 @@ srv_t_events_byterm <- function(id,
     # The R-code corresponding to the analysis.
     table_q <- shiny::reactive({
       validate_checks()
-      ANL <- merged$anl_q()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]]
 
       input_hlt <- as.vector(merged$anl_input_r()$columns_source$hlt)
       input_llt <- as.vector(merged$anl_input_r()$columns_source$llt)

--- a/R/tm_t_events_by_grade.R
+++ b/R/tm_t_events_by_grade.R
@@ -1116,7 +1116,10 @@ srv_t_events_by_grade <- function(id,
           shiny::need(
             is.factor(anl_filtered[[input_grade]]) &&
               all(as.character(unique(anl_filtered[[input_grade]])) %in% as.character(c(1:5))),
-            "Data includes records with grade levels outside of 1-5. Please use filter panel to exclude from analysis in order to display grade grouping in nested columns." # nolint
+            paste(
+              "Data includes records with grade levels outside of 1-5.",
+              "Please use filter panel to exclude from analysis in order to display grade grouping in nested columns."
+            )
           )
         )
       } else {
@@ -1141,7 +1144,7 @@ srv_t_events_by_grade <- function(id,
     # The R-code corresponding to the analysis.
     table_q <- shiny::reactive({
       validate_checks()
-      ANL <- merged$anl_q()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]]
 
       input_hlt <- as.vector(merged$anl_input_r()$columns_source$hlt)
       input_llt <- as.vector(merged$anl_input_r()$columns_source$llt)

--- a/R/tm_t_events_patyear.R
+++ b/R/tm_t_events_patyear.R
@@ -511,7 +511,7 @@ srv_events_patyear <- function(id,
     table_q <- shiny::reactive({
       validate_checks()
 
-      ANL <- merged$anl_q()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]]
       label_paramcd <- get_paramcd_label(ANL, paramcd)
 
       my_calls <- template_events_patyear(
@@ -525,7 +525,7 @@ srv_events_patyear <- function(id,
         total_label = total_label,
         na_level = na_level,
         control = control_incidence_rate(
-          conf_level = as.numeric(input$conf_level), # nolint
+          conf_level = as.numeric(input$conf_level),
           conf_type = if (input$conf_method == "Normal (rate)") {
             "normal"
           } else if (input$conf_method == "Normal (log rate)") {

--- a/R/tm_t_logistic.R
+++ b/R/tm_t_logistic.R
@@ -87,7 +87,7 @@ template_logistic <- function(dataname,
     data_list <- add_expr(
       data_list,
       substitute(
-        expr = ANL <- data_pipe, # nolint
+        expr = ANL <- data_pipe,
         env = list(data_pipe = pipe_expr(data_pipe))
       )
     )
@@ -96,7 +96,7 @@ template_logistic <- function(dataname,
   data_list <- add_expr(
     data_list,
     substitute(
-      expr = ANL <- df %>% # nolint
+      expr = ANL <- df %>%
         dplyr::mutate(Response = aval_var %in% responder_val) %>%
         df_explicit_na(na_level = "_NA_"),
       env = list(df = as.name("ANL"), aval_var = as.name(aval_var), responder_val = responder_val)
@@ -107,7 +107,7 @@ template_logistic <- function(dataname,
 
   if (!is.null(arm_var)) {
     y$relabel <- substitute(
-      expr = teal.data::col_labels(ANL[arm_var]) <- arm_var_lab, # nolint
+      expr = teal.data::col_labels(ANL[arm_var]) <- arm_var_lab,
       env = list(arm_var = arm_var)
     )
   }
@@ -658,7 +658,7 @@ srv_t_logistic <- function(id,
     all_q <- shiny::reactive({
       validate_checks()
 
-      ANL <- merged$anl_q()[["ANL"]] # nolint
+      ANL <- merged$anl_q()[["ANL"]]
 
       label_paramcd <- get_paramcd_label(ANL, paramcd)
 

--- a/R/tm_t_mult_events.R
+++ b/R/tm_t_mult_events.R
@@ -165,7 +165,7 @@ template_mult_events <- function(dataname,
 
       lbl_lst <- add_expr(
         lbl_lst,
-        substitute( # nolint
+        substitute(
           expr = attr(dataname$hlt_new, which = "label"),
           env = list(
             dataname = as.name(dataname),

--- a/R/tm_t_pp_basic_info.R
+++ b/R/tm_t_pp_basic_info.R
@@ -247,7 +247,7 @@ srv_t_basic_info <- function(id,
         substitute(
           expr = {
             pt_id <- patient_id
-            ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
+            ANL <- ANL[ANL[[patient_col]] == patient_id, ]
           }, env = list(
             patient_col = patient_col,
             patient_id = patient_id()

--- a/R/tm_t_pp_laboratory.R
+++ b/R/tm_t_pp_laboratory.R
@@ -473,7 +473,7 @@ srv_g_laboratory <- function(id,
         substitute(
           expr = {
             pt_id <- patient_id
-            ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
+            ANL <- ANL[ANL[[patient_col]] == patient_id, ]
           }, env = list(
             patient_col = patient_col,
             patient_id = patient_id()

--- a/R/tm_t_pp_medical_history.R
+++ b/R/tm_t_pp_medical_history.R
@@ -320,7 +320,7 @@ srv_t_medical_history <- function(id,
         anl_q(),
         substitute(
           expr = {
-            ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
+            ANL <- ANL[ANL[[patient_col]] == patient_id, ]
           }, env = list(
             patient_col = patient_col,
             patient_id = patient_id()

--- a/R/tm_t_pp_prior_medication.R
+++ b/R/tm_t_pp_prior_medication.R
@@ -319,7 +319,7 @@ srv_t_prior_medication <- function(id,
         teal.code::eval_code(
           substitute(
             expr = {
-              ANL <- ANL[ANL[[patient_col]] == patient_id, ] # nolint
+              ANL <- ANL[ANL[[patient_col]] == patient_id, ]
             }, env = list(
               patient_col = patient_col,
               patient_id = patient_id()

--- a/R/tm_t_shift_by_arm.R
+++ b/R/tm_t_shift_by_arm.R
@@ -22,7 +22,7 @@ template_shift_by_arm <- function(dataname,
                                   aval_var = "ANRIND",
                                   base_var = lifecycle::deprecated(),
                                   baseline_var = "BNRIND",
-                                  na.rm = FALSE, # nolint
+                                  na.rm = FALSE, # nolint: object_name.
                                   na_level = default_na_str(),
                                   add_total = FALSE,
                                   total_label = default_total_label(),
@@ -255,7 +255,7 @@ tm_t_shift_by_arm <- function(label,
                                 selected = "ONTRTFL"
                               ),
                               treatment_flag = teal.transform::choices_selected("Y"),
-                              useNA = c("ifany", "no"), # nolint
+                              useNA = c("ifany", "no"), # nolint: object_name.
                               na_level = default_na_str(),
                               add_total = FALSE,
                               total_label = default_total_label(),
@@ -277,7 +277,7 @@ tm_t_shift_by_arm <- function(label,
   checkmate::assert_string(label)
   checkmate::assert_string(dataname)
   checkmate::assert_string(parentname)
-  useNA <- match.arg(useNA) # nolint
+  useNA <- match.arg(useNA) # nolint: object_name.
   checkmate::assert_string(na_level)
   checkmate::assert_string(total_label)
   checkmate::assert_class(arm_var, "choices_selected")
@@ -546,7 +546,7 @@ srv_shift_by_arm <- function(id,
         treatment_flag = input$treatment_flag,
         aval_var = names(merged$anl_input_r()$columns_source$aval_var),
         baseline_var = names(merged$anl_input_r()$columns_source$baseline_var),
-        na.rm = ifelse(input$useNA == "ifany", FALSE, TRUE), # nolint
+        na.rm = ifelse(input$useNA == "ifany", FALSE, TRUE),
         na_level = na_level,
         add_total = input$add_total,
         total_label = total_label,

--- a/R/tm_t_shift_by_arm_by_worst.R
+++ b/R/tm_t_shift_by_arm_by_worst.R
@@ -22,7 +22,7 @@ template_shift_by_arm_by_worst <- function(dataname,
                                            aval_var = "ANRIND",
                                            base_var = lifecycle::deprecated(),
                                            baseline_var = "BNRIND",
-                                           na.rm = FALSE, # nolint
+                                           na.rm = FALSE, # nolint: object_name.
                                            na_level = default_na_str(),
                                            add_total = FALSE,
                                            total_label = default_total_label(),
@@ -266,7 +266,7 @@ tm_t_shift_by_arm_by_worst <- function(label,
                                          selected = "ONTRTFL"
                                        ),
                                        treatment_flag = teal.transform::choices_selected("Y"),
-                                       useNA = c("ifany", "no"), # nolint
+                                       useNA = c("ifany", "no"), # nolint: object_name.
                                        na_level = default_na_str(),
                                        add_total = FALSE,
                                        total_label = default_total_label(),
@@ -288,7 +288,7 @@ tm_t_shift_by_arm_by_worst <- function(label,
   checkmate::assert_string(label)
   checkmate::assert_string(dataname)
   checkmate::assert_string(parentname)
-  useNA <- match.arg(useNA) # nolint
+  useNA <- match.arg(useNA) # nolint: object_name.
   checkmate::assert_string(na_level)
   checkmate::assert_string(total_label)
   checkmate::assert_class(arm_var, "choices_selected")
@@ -581,7 +581,7 @@ srv_shift_by_arm_by_worst <- function(id,
         treatment_flag = input$treatment_flag,
         aval_var = names(merged$anl_input_r()$columns_source$aval_var),
         baseline_var = names(merged$anl_input_r()$columns_source$baseline_var),
-        na.rm = ifelse(input$useNA == "ifany", FALSE, TRUE), # nolint
+        na.rm = ifelse(input$useNA == "ifany", FALSE, TRUE),
         na_level = na_level,
         add_total = input$add_total,
         total_label = total_label,

--- a/R/tm_t_summary.R
+++ b/R/tm_t_summary.R
@@ -19,7 +19,7 @@ template_summary <- function(dataname,
                              add_total = TRUE,
                              total_label = default_total_label(),
                              var_labels = character(),
-                             na.rm = FALSE, # nolint
+                             na.rm = FALSE, # nolint: object_name.
                              na_level = default_na_str(),
                              numeric_stats = c(
                                "n", "mean_sd", "mean_ci", "median", "median_ci", "quantiles", "range", "geom_mean"
@@ -244,7 +244,7 @@ tm_t_summary <- function(label,
                          summarize_vars,
                          add_total = TRUE,
                          total_label = default_total_label(),
-                         useNA = c("ifany", "no"), # nolint
+                         useNA = c("ifany", "no"), # nolint: object_name.
                          na_level = default_na_str(),
                          numeric_stats = c(
                            "n", "mean_sd", "mean_ci", "median", "median_ci", "quantiles", "range", "geom_mean"
@@ -262,7 +262,7 @@ tm_t_summary <- function(label,
   checkmate::assert_class(summarize_vars, "choices_selected")
   checkmate::assert_string(na_level)
   checkmate::assert_character(numeric_stats, min.len = 1)
-  useNA <- match.arg(useNA) # nolint
+  useNA <- match.arg(useNA) # nolint: object_name.
   denominator <- match.arg(denominator)
   checkmate::assert_flag(drop_arm_levels)
   checkmate::assert_class(pre_output, classes = "shiny.tag", null.ok = TRUE)
@@ -523,7 +523,7 @@ srv_summary <- function(id,
         add_total = input$add_total,
         total_label = total_label,
         var_labels = var_labels,
-        na.rm = ifelse(input$useNA == "ifany", FALSE, TRUE), # nolint
+        na.rm = ifelse(input$useNA == "ifany", FALSE, TRUE),
         na_level = na_level,
         numeric_stats = input$numeric_stats,
         denominator = input$denominator,

--- a/R/tm_t_summary_by.R
+++ b/R/tm_t_summary_by.R
@@ -24,7 +24,7 @@ template_summary_by <- function(parentname,
                                 total_label = default_total_label(),
                                 parallel_vars = FALSE,
                                 row_groups = FALSE,
-                                na.rm = FALSE, # nolint
+                                na.rm = FALSE, # nolint: object_name.
                                 na_level = default_na_str(),
                                 numeric_stats = c(
                                   "n", "mean_sd", "mean_ci", "median", "median_ci", "quantiles", "range"
@@ -95,7 +95,7 @@ template_summary_by <- function(parentname,
   y$layout_prep <- quote(split_fun <- drop_split_levels)
   if (row_groups) {
     y$layout_cfun <- quote(
-      cfun_unique <- function(x, labelstr = "", .N_col) { # nolint
+      cfun_unique <- function(x, labelstr = "", .N_col) { # nolint: object_name.
         y <- length(unique(x))
         rcell(
           c(y, y / .N_col),
@@ -383,7 +383,7 @@ tm_t_summary_by <- function(label,
                             total_label = default_total_label(),
                             parallel_vars = FALSE,
                             row_groups = FALSE,
-                            useNA = c("ifany", "no"), # nolint
+                            useNA = c("ifany", "no"), # nolint: object_name.
                             na_level = default_na_str(),
                             numeric_stats = c("n", "mean_sd", "median", "range"),
                             denominator = teal.transform::choices_selected(c("n", "N", "omit"), "omit", fixed = TRUE),
@@ -396,7 +396,7 @@ tm_t_summary_by <- function(label,
   checkmate::assert_string(label)
   checkmate::assert_string(dataname)
   checkmate::assert_string(parentname)
-  useNA <- match.arg(useNA) # nolint
+  useNA <- match.arg(useNA) # nolint: object_name.
   checkmate::assert_string(na_level)
   checkmate::assert_class(arm_var, "choices_selected")
   checkmate::assert_class(by_vars, "choices_selected")

--- a/R/tm_t_tte.R
+++ b/R/tm_t_tte.R
@@ -644,7 +644,7 @@ ui_t_tte <- function(id, ...) {
             label = shiny::HTML(
               paste(
                 "p-value method for ",
-                shiny::span(class = "text-primary", "Coxph"), # nolint
+                shiny::span(class = "text-primary", "Coxph"),
                 " (Hazard Ratio)",
                 sep = ""
               )
@@ -657,7 +657,7 @@ ui_t_tte <- function(id, ...) {
             label = shiny::HTML(
               paste(
                 "Ties for ",
-                shiny::span(class = "text-primary", "Coxph"), # nolint
+                shiny::span(class = "text-primary", "Coxph"),
                 " (Hazard Ratio)",
                 sep = ""
               )
@@ -670,7 +670,7 @@ ui_t_tte <- function(id, ...) {
             label = shiny::HTML(
               paste(
                 "Confidence Level for ",
-                shiny::span(class = "text-primary", "Coxph"), # nolint
+                shiny::span(class = "text-primary", "Coxph"),
                 " (Hazard Ratio)",
                 sep = ""
               )
@@ -689,7 +689,7 @@ ui_t_tte <- function(id, ...) {
           label = shiny::HTML(
             paste(
               "Confidence Level for ",
-              shiny::span(class = "text-primary", "Survfit"), # nolint
+              shiny::span(class = "text-primary", "Survfit"),
               " (KM Median Estimate & Event Free Rate)",
               sep = ""
             )

--- a/R/utils.R
+++ b/R/utils.R
@@ -369,7 +369,7 @@ cs_to_des_filter <- function(cs, dataname, multiple = FALSE, include_vars = FALS
 #'
 #' @export
 #' @return (`logical`)
-is.cs_or_des <- function(x) { # nolint
+is.cs_or_des <- function(x) { # nolint: object_name.
   inherits(x, c("data_extract_spec", "choices_selected"))
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,4 @@
-.onLoad <- function(libname, pkgname) { # nolint
+.onLoad <- function(libname, pkgname) {
   teal.logger::register_logger(namespace = "teal.modules.clinical")
   tern::set_default_na_str("<Missing>")
 }

--- a/tests/testthat/test-tm_g_ci.R
+++ b/tests/testthat/test-tm_g_ci.R
@@ -11,7 +11,7 @@ testthat::test_that("1. and 2. Mean and 95% CIs for mean", {
   res <- testthat::expect_silent(result)
   testthat::expect_snapshot(res)
   # Check the output.
-  # eval(result) ; gg # nolint
+  # eval(result) ; gg # nolint: commented_code.
 })
 
 testthat::test_that("3. Confidence Interval Plot (using different stratification variable)", {
@@ -26,7 +26,7 @@ testthat::test_that("3. Confidence Interval Plot (using different stratification
   res <- testthat::expect_silent(result)
   testthat::expect_snapshot(res)
   # Check the output.
-  # eval(result) ; gg # nolint
+  # eval(result) ; gg # nolint: commented_code.
 })
 
 testthat::test_that("4. Median and 95% CIs for median", {
@@ -41,7 +41,7 @@ testthat::test_that("4. Median and 95% CIs for median", {
   res <- testthat::expect_silent(result)
   testthat::expect_snapshot(res)
   # Check the output.
-  # eval(result) ; gg # nolint
+  # eval(result) ; gg # nolint: commented_code.
 })
 
 testthat::test_that("5. Using different alpha level", {
@@ -57,5 +57,5 @@ testthat::test_that("5. Using different alpha level", {
   res <- testthat::expect_silent(result)
   testthat::expect_snapshot(res)
   # Check the output.
-  # eval(result) ; gg # nolint
+  # eval(result) ; gg # nolint: commented_code.
 })

--- a/vignettes/generate_tmc_test_data.Rmd
+++ b/vignettes/generate_tmc_test_data.Rmd
@@ -30,7 +30,7 @@ library(teal.data)
 
 study_duration_secs <- lubridate::seconds(lubridate::years(2))
 
-sample_fct <- function(x, N, ...) { # nolint object_name_linter.
+sample_fct <- function(x, N, ...) { # nolint: object_name.
   checkmate::assert_number(N)
   factor(sample(x, N, replace = TRUE, ...), levels = if (is.factor(x)) levels(x) else x)
 }
@@ -153,7 +153,7 @@ common_var_labels <- c(
 ## `ADSL`
 
 ```{r adsl, eval=FALSE, tidy = function(code, ...) gsub(pattern = "#\\s?nolint.*", replacement = "", code)}
-generate_adsl <- function(N = 200) { # nolint object_name_linter.
+generate_adsl <- function(N = 200) { # nolint: object_name.
   set.seed(1)
   sys_dtm <- lubridate::fast_strptime("20/2/2019 11:16:16.683", "%d/%m/%Y %H:%M:%OS", tz = "UTC")
   country_site_prob <- c(.5, .121, .077, .077, .075, .052, .046, .025, .014, .003)
@@ -210,8 +210,10 @@ generate_adsl <- function(N = 200) { # nolint object_name_linter.
       )) %>% with_label("Geographic Region 1"),
       SAFFL = factor("Y") %>% with_label("Safety Population Flag")
     ) %>%
-    dplyr::mutate(USUBJID = paste(.data$STUDYID, .data$SITEID, .data$SUBJID, sep = "-") %>%
-      with_label("Unique Subject Identifier"))
+    dplyr::mutate(
+      USUBJID = paste(.data$STUDYID, .data$SITEID, .data$SUBJID, sep = "-") %>%
+        with_label("Unique Subject Identifier")
+    )
 
   # disposition related variables
   # using probability of 1 for the "DEATH" level to ensure at least one death record exists
@@ -1723,8 +1725,8 @@ generate_adrs <- function(adsl = tmc_ex_adsl) {
       avisit <- c("SCREENING", "BASELINE", "CYCLE 2 DAY 1", "CYCLE 4 DAY 1", "END OF INDUCTION", "FOLLOW UP")
 
       # meaningful date information
-      TRTSTDT <- lubridate::date(pinfo$TRTSDTM) # nolint object_name_linter.
-      TRTENDT <- lubridate::date(dplyr::if_else( # nolint object_name_linter.
+      TRTSTDT <- lubridate::date(pinfo$TRTSDTM) # nolint: object_name.
+      TRTENDT <- lubridate::date(dplyr::if_else( # nolint: object_name.
         !is.na(pinfo$TRTEDTM), pinfo$TRTEDTM,
         lubridate::floor_date(TRTSTDT + study_duration_secs, unit = "day")
       ))

--- a/vignettes/generate_tmc_test_data.Rmd
+++ b/vignettes/generate_tmc_test_data.Rmd
@@ -16,6 +16,12 @@ editor_options:
         wrap: 72
 ---
 
+```{r, include=FALSE}
+knitr::opts_template$set(
+  remove_linter_comments = list(tidy = function(code, ...) gsub(pattern = "#\\s?nolint.*", replacement = "", code))
+)
+```
+
 ## Generating minimal data to test `teal.modules.clinical`
 
 The following script is used to create and save cached synthetic `CDISC` data to the `data/` directory to use in examples and tests in the `teal.modules.clinical` package. This script/vignette was initialized by Emily de la Rua in `tern`.
@@ -24,7 +30,7 @@ _Disclaimer_: this vignette concerns mainly the development of minimal and stabl
 
 ## Setup & Helper Functions
 
-```{r setup, eval=FALSE, tidy = function(code, ...) gsub(pattern = "#\\s?nolint.*", replacement = "", code)}
+```{r setup, eval=FALSE, opts.label=c("remove_linter_comments")}
 library(dplyr)
 library(teal.data)
 
@@ -152,7 +158,7 @@ common_var_labels <- c(
 
 ## `ADSL`
 
-```{r adsl, eval=FALSE, tidy = function(code, ...) gsub(pattern = "#\\s?nolint.*", replacement = "", code)}
+```{r adsl, eval=FALSE, opts.label=c("remove_linter_comments")}
 generate_adsl <- function(N = 200) { # nolint: object_name.
   set.seed(1)
   sys_dtm <- lubridate::fast_strptime("20/2/2019 11:16:16.683", "%d/%m/%Y %H:%M:%OS", tz = "UTC")
@@ -1687,7 +1693,7 @@ generate_adqs <- function(adsl = tmc_ex_adsl,
 
 ## `ADRS`
 
-```{r adrs, eval=FALSE, tidy = function(code, ...) gsub(pattern = "#\\s?nolint.*", replacement = "", code)}
+```{r adrs, eval=FALSE, opts.label=c("remove_linter_comments")}
 generate_adrs <- function(adsl = tmc_ex_adsl) {
   set.seed(1)
   param_codes <- stats::setNames(1:5, c("CR", "PR", "SD", "PD", "NE"))


### PR DESCRIPTION
# Pull Request

Fixes #1090 

#### Changes description

- Adds `object_name` rule that is friendly to variables with CDISC dataset names and `ANL` variables
- Converts all `# nolint` comments to specific rules
- Removes unnecessary `# nolint` comments
- Corrects indentation in code (that removes `indentation_linter` rule from `.lintr`)
