### PR TITLE
898 save app state version 3

### DIFF
--- a/R/tm_a_gee.R
+++ b/R/tm_a_gee.R
@@ -390,6 +390,9 @@ srv_gee <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     ## split_covariates ----
     shiny::observeEvent(input[[extract_input("cov_var", dataname)]],
       ignoreNULL = FALSE,
@@ -408,7 +411,7 @@ srv_gee <- function(id,
         teal.widgets::updateOptionalSelectInput(
           session,
           inputId = extract_input("split_covariates", dataname),
-          selected = split_covariates_selected
+          selected = shiny::restoreInput(ns(extract_input("split_covariates", dataname)), split_covariates_selected)
         )
       }
     )

--- a/R/tm_a_mmrm.R
+++ b/R/tm_a_mmrm.R
@@ -846,6 +846,9 @@ srv_mmrm <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     # Reactive responsible for sending a disable/enable signal
     # to show R code and debug info buttons
     disable_r_code <- shiny::reactiveVal(FALSE)
@@ -863,7 +866,7 @@ srv_mmrm <- function(id,
       teal.widgets::updateOptionalSelectInput(
         session,
         inputId = extract_input("split_covariates", dataname),
-        selected = split_covariates_selected
+        selected = shiny::restoreInput(ns(extract_input("split_covariates", dataname)), split_covariates_selected)
       )
     })
 

--- a/R/tm_g_forest_rsp.R
+++ b/R/tm_g_forest_rsp.R
@@ -509,6 +509,9 @@ srv_g_forest_rsp <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     # Setup arm variable selection, default reference arms, and default
     # comparison arms for encoding panel
     iv_arm_ref <- arm_ref_comp_observer(
@@ -609,7 +612,7 @@ srv_g_forest_rsp <- function(id,
         shiny::updateSelectInput(
           session, "responders",
           choices = responder_choices,
-          selected = intersect(responder_choices, common_rsp)
+          selected = shiny::restoreInput(ns("responders"), intersect(responder_choices, common_rsp))
         )
       }
     )

--- a/R/tm_g_pp_adverse_events.R
+++ b/R/tm_g_pp_adverse_events.R
@@ -443,6 +443,9 @@ srv_g_adverse_events <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     patient_id <- shiny::reactive(input$patient_id)
 
     # Init
@@ -451,7 +454,7 @@ srv_g_adverse_events <- function(id,
       session,
       "patient_id",
       choices = patient_data_base(),
-      selected = patient_data_base()[1]
+      selected = shiny::restoreInput(ns("patient_id"), patient_data_base()[1])
     )
 
     shiny::observeEvent(patient_data_base(),
@@ -460,11 +463,14 @@ srv_g_adverse_events <- function(id,
           session,
           "patient_id",
           choices = patient_data_base(),
-          selected = if (length(patient_data_base()) == 1) {
-            patient_data_base()
-          } else {
-            intersect(patient_id(), patient_data_base())
-          }
+          selected = shiny::restoreInput(
+            ns("patient_id"),
+            if (length(patient_data_base()) == 1) {
+              patient_data_base()
+            } else {
+              intersect(patient_id(), patient_data_base())
+            }
+          )
         )
       },
       ignoreInit = TRUE

--- a/R/tm_g_pp_patient_timeline.R
+++ b/R/tm_g_pp_patient_timeline.R
@@ -714,6 +714,9 @@ srv_g_patient_timeline <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     patient_id <- shiny::reactive(input$patient_id)
 
     # Init
@@ -722,7 +725,7 @@ srv_g_patient_timeline <- function(id,
       session,
       "patient_id",
       choices = patient_data_base(),
-      selected = patient_data_base()[1]
+      selected = shiny::restoreInputns(ns("patient_id"), patient_data_base()[1])
     )
 
     shiny::observeEvent(patient_data_base(),
@@ -731,11 +734,14 @@ srv_g_patient_timeline <- function(id,
           session,
           "patient_id",
           choices = patient_data_base(),
-          selected = if (length(patient_data_base()) == 1) {
-            patient_data_base()
-          } else {
-            intersect(patient_id(), patient_data_base())
-          }
+          selected = shiny::restoreInputns(
+            ns("patient_id"),
+            if (length(patient_data_base()) == 1) {
+              patient_data_base()
+            } else {
+              intersect(patient_id(), patient_data_base())
+            }
+          )
         )
       },
       ignoreInit = TRUE

--- a/R/tm_g_pp_therapy.R
+++ b/R/tm_g_pp_therapy.R
@@ -559,13 +559,17 @@ srv_g_therapy <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     patient_id <- shiny::reactive(input$patient_id)
 
     # Init
     patient_data_base <- shiny::reactive(unique(data()[[parentname]][[patient_col]]))
     teal.widgets::updateOptionalSelectInput(
       session, "patient_id",
-      choices = patient_data_base(), selected = patient_data_base()[1]
+      choices = patient_data_base(),
+      selected = shiny::restoreInputns(ns("patient_id"), patient_data_base()[1])
     )
 
     shiny::observeEvent(patient_data_base(),
@@ -574,11 +578,14 @@ srv_g_therapy <- function(id,
           session,
           "patient_id",
           choices = patient_data_base(),
-          selected = if (length(patient_data_base()) == 1) {
-            patient_data_base()
-          } else {
-            intersect(patient_id(), patient_data_base())
-          }
+          selected = shiny::restoreInputns(
+            ns("patient_id"),
+            if (length(patient_data_base()) == 1) {
+              patient_data_base()
+            } else {
+              intersect(patient_id(), patient_data_base())
+            }
+          )
         )
       },
       ignoreInit = TRUE

--- a/R/tm_g_pp_vitals.R
+++ b/R/tm_g_pp_vitals.R
@@ -412,6 +412,9 @@ srv_g_vitals <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     patient_id <- shiny::reactive(input$patient_id)
 
     # Init
@@ -420,7 +423,7 @@ srv_g_vitals <- function(id,
       session,
       "patient_id",
       choices = patient_data_base(),
-      selected = patient_data_base()[1]
+      selected = shiny::restoreInputns(ns("patient_id"), patient_data_base()[1])
     )
 
     shiny::observeEvent(patient_data_base(),
@@ -429,11 +432,14 @@ srv_g_vitals <- function(id,
           session,
           "patient_id",
           choices = patient_data_base(),
-          selected = if (length(patient_data_base()) == 1) {
-            patient_data_base()
-          } else {
-            intersect(patient_id(), patient_data_base())
-          }
+          selected = shiny::restoreInputns(
+            ns("patient_id"),
+            if (length(patient_data_base()) == 1) {
+              patient_data_base()
+            } else {
+              intersect(patient_id(), patient_data_base())
+            }
+          )
         )
       },
       ignoreInit = TRUE

--- a/R/tm_t_abnormality.R
+++ b/R/tm_t_abnormality.R
@@ -506,6 +506,9 @@ srv_t_abnormality <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     selector_list <- teal.transform::data_extract_multiple_srv(
       data_extract = list(
         arm_var = arm_var,
@@ -544,7 +547,7 @@ srv_t_abnormality <- function(id,
         session = session,
         inputId = "treatment_flag",
         choices = resolved$choices,
-        selected = resolved$selected
+        selected = shiny::restoreInputns(ns("treatment_flag"), resolved$selected)
       )
     })
 

--- a/R/tm_t_abnormality_by_worst_grade.R
+++ b/R/tm_t_abnormality_by_worst_grade.R
@@ -504,13 +504,16 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint: object_length.
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     shiny::isolate({
       resolved <- teal.transform::resolve_delayed(worst_flag_indicator, as.list(data()@env))
       teal.widgets::updateOptionalSelectInput(
         session = session,
         inputId = "worst_flag_indicator",
         choices = resolved$choices,
-        selected = resolved$selected
+        selected = rshiny::restoreInputns(ns("worst_flag_indicator"), esolved$selected)
       )
     })
 

--- a/R/tm_t_ancova.R
+++ b/R/tm_t_ancova.R
@@ -697,6 +697,9 @@ srv_ancova <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     # Setup arm variable selection, default reference arms, and default
     # comparison arms for encoding panel.
     iv_arco <- arm_ref_comp_observer(
@@ -796,7 +799,7 @@ srv_ancova <- function(id,
               session,
               "interact_y",
               selected = interact_select,
-              choices = interact_choices
+              choices = shiny::restoreInputns(ns("interact_y"), interact_choices)
             )
           }
         }

--- a/R/tm_t_binary_outcome.R
+++ b/R/tm_t_binary_outcome.R
@@ -712,6 +712,9 @@ srv_t_binary_outcome <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     # Setup arm variable selection, default reference arms, and default
     # comparison arms for encoding panel
     iv_arm_ref <- arm_ref_comp_observer(
@@ -804,7 +807,7 @@ srv_t_binary_outcome <- function(id,
         shiny::updateSelectInput(
           session, "responders",
           choices = responder_choices,
-          selected = intersect(responder_choices, common_rsp)
+          selected = shiny::restoreInputns(ns("responders"), intersect(responder_choices, common_rsp))
         )
       }
     )

--- a/R/tm_t_events_patyear.R
+++ b/R/tm_t_events_patyear.R
@@ -402,6 +402,9 @@ srv_events_patyear <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     shiny::observeEvent(anl_q(), {
       data_anl <- merged$anl_q()[["ANL"]]
       aval_unit_var <- merged$anl_input_r()$columns_source$avalu_var
@@ -413,7 +416,7 @@ srv_events_patyear <- function(id,
           session,
           "input_time_unit",
           choices = choices,
-          selected = choices[1]
+          selected = shiny::restoreInputns(ns("input_time_unit"), choices[1])
         )
       }
     })

--- a/R/tm_t_logistic.R
+++ b/R/tm_t_logistic.R
@@ -451,6 +451,9 @@ srv_t_logistic <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     # Observer to update reference and comparison arm input options.
     iv_arco <- arm_ref_comp_observer(
       session,
@@ -554,7 +557,7 @@ srv_t_logistic <- function(id,
       shiny::updateSelectInput(
         session, "responders",
         choices = responder_choices,
-        selected = responder_sel
+        selected = shiny::restoreInputns(ns("responders"), responder_sel)
       )
     })
 

--- a/R/tm_t_pp_basic_info.R
+++ b/R/tm_t_pp_basic_info.R
@@ -181,6 +181,9 @@ srv_t_basic_info <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     patient_id <- shiny::reactive(input$patient_id)
 
     # Init
@@ -189,7 +192,7 @@ srv_t_basic_info <- function(id,
       session,
       "patient_id",
       choices = patient_data_base(),
-      selected = patient_data_base()[1]
+      selected = shiny::restoreInputns(ns("patient_id"), patient_data_base()[1])
     )
 
     shiny::observeEvent(patient_data_base(),
@@ -198,11 +201,14 @@ srv_t_basic_info <- function(id,
           session,
           "patient_id",
           choices = patient_data_base(),
-          selected = if (length(patient_data_base()) == 1) {
-            patient_data_base()
-          } else {
-            intersect(patient_id(), patient_data_base())
-          }
+          selected = shiny::restoreInputns(
+            ns("patient_id"),
+            if (length(patient_data_base()) == 1) {
+              patient_data_base()
+            } else {
+              intersect(patient_id(), patient_data_base())
+            }
+          )
         )
       },
       ignoreInit = TRUE

--- a/R/tm_t_pp_laboratory.R
+++ b/R/tm_t_pp_laboratory.R
@@ -377,6 +377,9 @@ srv_g_laboratory <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     patient_id <- shiny::reactive(input$patient_id)
 
     # Init
@@ -385,7 +388,7 @@ srv_g_laboratory <- function(id,
       session,
       "patient_id",
       choices = patient_data_base(),
-      selected = patient_data_base()[1]
+      selected = shiny::restoreInputns(ns("patient_id"), patient_data_base()[1])
     )
 
     shiny::observeEvent(patient_data_base(),
@@ -394,11 +397,14 @@ srv_g_laboratory <- function(id,
           session,
           "patient_id",
           choices = patient_data_base(),
-          selected = if (length(patient_data_base()) == 1) {
-            patient_data_base()
-          } else {
-            intersect(patient_id(), patient_data_base())
-          }
+          selected = shiny::restoreInputns(
+            ns("patient_id"),
+            if (length(patient_data_base()) == 1) {
+              patient_data_base()
+            } else {
+              intersect(patient_id(), patient_data_base())
+            }
+          )
         )
       },
       ignoreInit = TRUE
@@ -413,7 +419,7 @@ srv_g_laboratory <- function(id,
       session,
       "round_value",
       choices = seq(0, max_decimal),
-      selected = min(4, max_decimal)
+      selected = shiny::restoreInputns(ns("round_value"), min(4, max_decimal))
     )
 
     # Laboratory values tab ----

--- a/R/tm_t_pp_medical_history.R
+++ b/R/tm_t_pp_medical_history.R
@@ -245,13 +245,17 @@ srv_t_medical_history <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     patient_id <- shiny::reactive(input$patient_id)
 
     # Init
     patient_data_base <- shiny::reactive(unique(data()[[parentname]][[patient_col]]))
     teal.widgets::updateOptionalSelectInput(
       session, "patient_id",
-      choices = patient_data_base(), selected = patient_data_base()[1]
+      choices = patient_data_base(),
+      selected = shiny::restoreInputns(ns("patient_id"), patient_data_base()[1])
     )
 
     shiny::observeEvent(patient_data_base(),
@@ -260,11 +264,14 @@ srv_t_medical_history <- function(id,
           session,
           "patient_id",
           choices = patient_data_base(),
-          selected = if (length(patient_data_base()) == 1) {
-            patient_data_base()
-          } else {
-            intersect(patient_id(), patient_data_base())
-          }
+          selected = shiny::restoreInputns(
+            ns("patient_id"),
+            if (length(patient_data_base()) == 1) {
+              patient_data_base()
+            } else {
+              intersect(patient_id(), patient_data_base())
+            }
+          )
         )
       },
       ignoreInit = TRUE

--- a/R/tm_t_pp_prior_medication.R
+++ b/R/tm_t_pp_prior_medication.R
@@ -243,6 +243,9 @@ srv_t_prior_medication <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     patient_id <- shiny::reactive(input$patient_id)
 
     selector_list <- teal.transform::data_extract_multiple_srv(
@@ -273,7 +276,7 @@ srv_t_prior_medication <- function(id,
       session,
       "patient_id",
       choices = patient_data_base(),
-      selected = patient_data_base()[1]
+      selected = shiny::restoreInputns(ns("patient_id"), patient_data_base()[1])
     )
 
     shiny::observeEvent(patient_data_base(),
@@ -282,11 +285,14 @@ srv_t_prior_medication <- function(id,
           session,
           "patient_id",
           choices = patient_data_base(),
-          selected = if (length(patient_data_base()) == 1) {
-            patient_data_base()
-          } else {
-            intersect(patient_id(), patient_data_base())
-          }
+          selected = shiny::restoreInputns(
+            ns("patient_id"),
+            if (length(patient_data_base()) == 1) {
+              patient_data_base()
+            } else {
+              intersect(patient_id(), patient_data_base())
+            }
+          )
         )
       },
       ignoreInit = TRUE

--- a/R/tm_t_shift_by_arm.R
+++ b/R/tm_t_shift_by_arm.R
@@ -437,6 +437,9 @@ srv_shift_by_arm <- function(id,
   checkmate::assert_class(data, "reactive")
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     selector_list <- teal.transform::data_extract_multiple_srv(
       data_extract = list(
         arm_var = arm_var,
@@ -465,7 +468,7 @@ srv_shift_by_arm <- function(id,
         session = session,
         inputId = "treatment_flag",
         choices = resolved$choices,
-        selected = resolved$selected
+        selected = shiny::restoreInputns(ns("treatment_flag"), resolved$selected)
       )
     })
 

--- a/R/tm_t_shift_by_arm_by_worst.R
+++ b/R/tm_t_shift_by_arm_by_worst.R
@@ -457,6 +457,9 @@ srv_shift_by_arm_by_worst <- function(id,
   checkmate::assert_class(data, "reactive")
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
   shiny::moduleServer(id, function(input, output, session) {
+
+    ns <- session$ns
+
     selector_list <- teal.transform::data_extract_multiple_srv(
       data_extract = list(
         arm_var = arm_var,
@@ -485,7 +488,7 @@ srv_shift_by_arm_by_worst <- function(id,
         session = session,
         inputId = "treatment_flag",
         choices = resolved$choices,
-        selected = resolved$selected
+        selected = shiny::restoreInputns(ns("treatment_flag"), resolved$selected)
       )
     })
 


### PR DESCRIPTION
Companion to https://github.com/insightsengineering/teal/pull/1011
Adds `shiny::restoreInput` calls to the `value`/`choices` arguments in `update*Input` calls.