### PR TITLE
remove stop() in test-examples.R

### DIFF
--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -1,3 +1,5 @@
+testthat::skip_on_cran()
+
 # this test requires a `man` directory in the `tests/testthat` directory
 # (presumably symlinked to the package root `man` directory to avoid duplication)
 # this also requires `devtools::document()` to be run before running the tests
@@ -121,7 +123,6 @@ for (i in rd_files()) {
   testthat::test_that(
     paste0("example-", basename(i)),
     {
-      testthat::skip_on_cran()
       if (basename(i) %in% strict_exceptions) {
         op <- options()
         withr::local_options(opts_partial_match_old)

--- a/tests/testthat/test-examples.R
+++ b/tests/testthat/test-examples.R
@@ -1,5 +1,3 @@
-testthat::skip_on_cran()
-
 # this test requires a `man` directory in the `tests/testthat` directory
 # (presumably symlinked to the package root `man` directory to avoid duplication)
 # this also requires `devtools::document()` to be run before running the tests
@@ -9,10 +7,6 @@ rd_files <- function() {
     testthat::test_path("..", "..", "00_pkg_src", testthat::testing_package(), "man")
   } else {
     testthat::test_path("..", "..", "man")
-  }
-
-  if (!dir.exists(man_path)) {
-    stop("Cannot find path to `man` directory.")
   }
 
   list.files(
@@ -123,6 +117,7 @@ for (i in rd_files()) {
   testthat::test_that(
     paste0("example-", basename(i)),
     {
+      testthat::skip_on_cran()
       if (basename(i) %in% strict_exceptions) {
         op <- options()
         withr::local_options(opts_partial_match_old)


### PR DESCRIPTION
put up `skip_on_cran()` so that we don't run `rd_files()`