### PR TITLE
Post cleanup shinytest2 

### DIFF
--- a/tests/testthat/test-shinytest2-tm_a_gee.R
+++ b/tests/testthat/test-shinytest2-tm_a_gee.R
@@ -24,6 +24,7 @@ app_driver_tm_a_gee <- function() {
     modules = tm_a_gee(
       label = "GEE",
       dataname = "ADQS",
+      parentname = "ADSL",
       aval_var = teal.transform::choices_selected("AVALBIN", fixed = TRUE),
       id_var = teal.transform::choices_selected(c("USUBJID", "SUBJID"), "USUBJID"),
       arm_var = teal.transform::choices_selected(c("ARM", "ARMCD"), "ARM"),
@@ -33,7 +34,11 @@ app_driver_tm_a_gee <- function() {
         selected = "FKSI-FWB"
       ),
       cov_var = teal.transform::choices_selected(c("BASE", "AGE", "SEX", "BASE:AVISIT"), NULL),
-      conf_level = teal.transform::choices_selected(c(0.95, 0.9, 0.8, -1), 0.95, keep_order = TRUE)
+      conf_level = teal.transform::choices_selected(c(0.95, 0.9, 0.8, -1), 0.95, keep_order = TRUE),
+      arm_ref_comp = NULL,
+      pre_output = NULL,
+      post_output = NULL,
+      basic_table_args = teal.widgets::basic_table_args()
     )
   )
 }
@@ -108,9 +113,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_a_gee()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input(ns_des_input("id_var", "ADQS", "select"), "SUBJID")
-    testthat::expect_true(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_true(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -120,7 +125,7 @@ testthat::test_that("e2e - tm_a_gee: Deselection of id_var throws validation err
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_a_gee()
   app_driver$set_active_module_input(ns_des_input("id_var", "ADQS", "select"), character(0))
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("id_var-dataset_ADQS_singleextract-select_input > div > span"),
@@ -133,9 +138,9 @@ testthat::test_that("e2e - tm_a_gee: Change in arm_var changes the table and doe
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_a_gee()
 
-  table_before <- app_driver$get_active_module_tws_output("table")
+  table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input(ns_des_input("arm_var", "ADSL", "select"), "ARMCD")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -144,7 +149,7 @@ testthat::test_that("e2e - tm_a_gee: Deselection of arm_var throws validation er
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_a_gee()
   app_driver$set_active_module_input(ns_des_input("arm_var", "ADSL", "select"), character(0))
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input > div > span"),
@@ -158,9 +163,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_a_gee()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input(ns_des_input("visit_var", "ADQS", "select"), "AVISITN")
-    testthat::expect_true(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_true(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -171,7 +176,7 @@ testthat::test_that("e2e - tm_a_gee: Deselection of visit_var throws validation 
   app_driver <- app_driver_tm_a_gee()
   app_driver$set_active_module_input(ns_des_input("visit_var", "ADQS", "select"), character(0))
   app_driver$wait_for_idle()
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("visit_var-dataset_ADQS_singleextract-select_input > div > span"),
@@ -183,9 +188,9 @@ testthat::test_that("e2e - tm_a_gee: Deselection of visit_var throws validation 
 testthat::test_that("e2e - tm_a_gee: Selection of paramcd changes the table and does not throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_a_gee()
-  table_before <- app_driver$get_active_module_tws_output("table")
+  table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input(ns_des_input("paramcd", "ADQS", "filter1-vals"), "BFIALL")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -194,7 +199,7 @@ testthat::test_that("e2e - tm_a_gee: Deselection of paramcd throws validation er
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_a_gee()
   app_driver$set_active_module_input(ns_des_input("paramcd", "ADQS", "filter1-vals"), character(0))
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("paramcd-dataset_ADQS_singleextract-filter1-vals_input > div > span"),
@@ -206,9 +211,9 @@ testthat::test_that("e2e - tm_a_gee: Deselection of paramcd throws validation er
 testthat::test_that("e2e - tm_a_gee: Selection of cov_var changes the table and does not throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_a_gee()
-  table_before <- app_driver$get_active_module_tws_output("table")
+  table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input("cov_var-dataset_ADQS_singleextract-select", "BASE")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -216,9 +221,9 @@ testthat::test_that("e2e - tm_a_gee: Selection of cov_var changes the table and 
 testthat::test_that("e2e - tm_a_gee: Selection of conf_level changes the table and does not throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_a_gee()
-  table_before <- app_driver$get_active_module_tws_output("table")
+  table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input("conf_level", 0.90)
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -226,9 +231,9 @@ testthat::test_that("e2e - tm_a_gee: Selection of conf_level changes the table a
 testthat::test_that("e2e - tm_a_gee: Selection of conf_level out of [0,1] range throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_a_gee()
-  table_before <- app_driver$get_active_module_tws_output("table")
+  table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input("conf_level", -1)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("conf_level_input > div > span"),
@@ -241,7 +246,7 @@ testthat::test_that("e2e - tm_a_gee: Deselection of conf_level throws validation
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_a_gee()
   app_driver$set_active_module_input("conf_level", character(0))
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("conf_level_input > div > span"),
@@ -253,9 +258,9 @@ testthat::test_that("e2e - tm_a_gee: Deselection of conf_level throws validation
 testthat::test_that("e2e - tm_a_gee: Selection of cor_struct changes the table and does not throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_a_gee()
-  table_before <- app_driver$get_active_module_tws_output("table")
+  table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input("cor_struct", "auto-regressive")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -271,9 +276,9 @@ testthat::test_that("e2e - tm_a_gee: Deselection of cor_struct does not throw va
 testthat::test_that("e2e - tm_a_gee: Selection of output_table changes the table and doesn't throw validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_a_gee()
-  table_before <- app_driver$get_active_module_tws_output("table")
+  table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input("output_table", "t_gee_cov")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })

--- a/tests/testthat/test-shinytest2-tm_a_gee.R
+++ b/tests/testthat/test-shinytest2-tm_a_gee.R
@@ -115,7 +115,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_a_gee()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input(ns_des_input("id_var", "ADQS", "select"), "SUBJID")
-    testthat::expect_true(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -140,7 +145,12 @@ testthat::test_that("e2e - tm_a_gee: Change in arm_var changes the table and doe
 
   table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input(ns_des_input("arm_var", "ADSL", "select"), "ARMCD")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+  testthat::expect_false(
+    identical(
+      table_before,
+      app_driver$get_active_module_table_output("table-table-with-settings")
+    )
+  )
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -165,7 +175,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_a_gee()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input(ns_des_input("visit_var", "ADQS", "select"), "AVISITN")
-    testthat::expect_true(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -190,7 +205,12 @@ testthat::test_that("e2e - tm_a_gee: Selection of paramcd changes the table and 
   app_driver <- app_driver_tm_a_gee()
   table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input(ns_des_input("paramcd", "ADQS", "filter1-vals"), "BFIALL")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+  testthat::expect_false(
+    identical(
+      table_before,
+      app_driver$get_active_module_table_output("table-table-with-settings")
+    )
+  )
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -213,7 +233,12 @@ testthat::test_that("e2e - tm_a_gee: Selection of cov_var changes the table and 
   app_driver <- app_driver_tm_a_gee()
   table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input("cov_var-dataset_ADQS_singleextract-select", "BASE")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+  testthat::expect_false(
+    identical(
+      table_before,
+      app_driver$get_active_module_table_output("table-table-with-settings")
+    )
+  )
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -223,7 +248,12 @@ testthat::test_that("e2e - tm_a_gee: Selection of conf_level changes the table a
   app_driver <- app_driver_tm_a_gee()
   table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input("conf_level", 0.90)
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+  testthat::expect_false(
+    identical(
+      table_before,
+      app_driver$get_active_module_table_output("table-table-with-settings")
+    )
+  )
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -260,7 +290,12 @@ testthat::test_that("e2e - tm_a_gee: Selection of cor_struct changes the table a
   app_driver <- app_driver_tm_a_gee()
   table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input("cor_struct", "auto-regressive")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+  testthat::expect_false(
+    identical(
+      table_before,
+      app_driver$get_active_module_table_output("table-table-with-settings")
+    )
+  )
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -278,7 +313,12 @@ testthat::test_that("e2e - tm_a_gee: Selection of output_table changes the table
   app_driver <- app_driver_tm_a_gee()
   table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input("output_table", "t_gee_cov")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+  testthat::expect_false(
+    identical(
+      table_before,
+      app_driver$get_active_module_table_output("table-table-with-settings")
+    )
+  )
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })

--- a/tests/testthat/test-shinytest2-tm_a_gee.R
+++ b/tests/testthat/test-shinytest2-tm_a_gee.R
@@ -115,7 +115,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_a_gee()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input(ns_des_input("id_var", "ADQS", "select"), "SUBJID")
-    testthat::expect_false(
+    testthat::expect_true(
       identical(
         table_before,
         app_driver$get_active_module_table_output("table-table-with-settings")
@@ -175,7 +175,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_a_gee()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input(ns_des_input("visit_var", "ADQS", "select"), "AVISITN")
-    testthat::expect_false(
+    testthat::expect_true(
       identical(
         table_before,
         app_driver$get_active_module_table_output("table-table-with-settings")

--- a/tests/testthat/test-shinytest2-tm_a_mmrm.R
+++ b/tests/testthat/test-shinytest2-tm_a_mmrm.R
@@ -264,7 +264,9 @@ for (func in output_functions) {
       if (grepl("^g_", func)) {
         testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
+        testthat::expect_identical(
+          app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame()
+        )
       }
 
       testthat::expect_match(
@@ -297,7 +299,9 @@ for (func in output_functions) {
       if (grepl("^g_", func)) {
         testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
+        testthat::expect_identical(
+          app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame()
+        )
       }
 
       testthat::expect_match(
@@ -330,7 +334,9 @@ for (func in output_functions) {
       if (grepl("^g_", func)) {
         testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
+        testthat::expect_identical(
+          app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame()
+        )
       }
 
       testthat::expect_match(
@@ -363,7 +369,9 @@ for (func in output_functions) {
       if (grepl("^g_", func)) {
         testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
+        testthat::expect_identical(
+          app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame()
+        )
       }
 
       testthat::expect_match(
@@ -396,7 +404,9 @@ for (func in output_functions) {
       if (grepl("^g_", func)) {
         testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
+        testthat::expect_identical(
+          app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame()
+        )
       }
 
       testthat::expect_match(
@@ -429,7 +439,9 @@ for (func in output_functions) {
       if (grepl("^g_", func)) {
         testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
+        testthat::expect_identical(
+          app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame()
+        )
       }
 
       testthat::expect_match(

--- a/tests/testthat/test-shinytest2-tm_a_mmrm.R
+++ b/tests/testthat/test-shinytest2-tm_a_mmrm.R
@@ -79,10 +79,7 @@ output_functions <- c(
 )
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_a_mmrm: Module initializes in teal without errors ",
-    "and displays a message to click 'Fit Model'"
-  ),
+  "e2e - tm_a_mmrm: Module initializes in teal without errors and displays a message to click 'Fit Model'.",
   {
     skip_if_too_deep(5)
 
@@ -99,11 +96,9 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_a_mmrm: Module initializes with specified label, aval_var, paramcd,",
-    "visit_var, cov_var, arm_var, buckets, combine_comp_arms, id_var,",
-    "cor_struct, weights_emmeans, conf_level, method, parallel and output_function"
-  ),
+  "e2e - tm_a_mmrm: Module initializes with specified label, aval_var, paramcd,
+  visit_var, cov_var, arm_var, buckets, combine_comp_arms, id_var, cor_struct,
+  weights_emmeans, conf_level, method, parallel and output_function.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_a_mmrm(FALSE)
@@ -156,7 +151,7 @@ testthat::test_that("e2e - tm_a_mmrm: Click on fit model shows table for default
   app_driver <- app_driver_tm_a_mmrm()
   app_driver$expect_no_validation_error()
 
-  table <- app_driver$get_active_module_tws_output("mmrm_table")
+  table <- app_driver$get_active_module_table_output("mmrm_table-table-with-settings")
   col_val <- app_driver$get_active_module_input("buckets")
   testthat::expect_true(all(unlist(col_val, use.names = FALSE) %in% colnames(table)))
   testthat::expect_equal(nrow(table), 25)
@@ -165,10 +160,8 @@ testthat::test_that("e2e - tm_a_mmrm: Click on fit model shows table for default
 })
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_a_mmrm: function t_mmrm_lsmeans selection shows output settings; changing",
-    "settings throws no validation errors and verify visibility of generated tables."
-  ),
+  "e2e - tm_a_mmrm: Function t_mmrm_lsmeans selection shows output settings; changing
+  settings throws no validation errors and verify visibility of generated tables.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_a_mmrm()
@@ -187,10 +180,8 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_a_mmrm: function g_mmrm_lsmeans selection shows output settings; changing",
-    "settings throws no validation errors and verify visibility of generated plots."
-  ),
+  "e2e - tm_a_mmrm: Function g_mmrm_lsmeans selection shows output settings; changing
+  settings throws no validation errors and verify visibility of generated plots.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_a_mmrm()
@@ -201,7 +192,7 @@ testthat::test_that(
     app_driver$set_active_module_input("output_function", "g_mmrm_lsmeans", wait_ = FALSE)
     app_driver$expect_no_validation_error()
 
-    plot_before <- app_driver$get_active_module_pws_output("mmrm_plot")
+    plot_before <- app_driver$get_active_module_plot_output("mmrm_plot")
     testthat::expect_match(plot_before, "data:image/png;base64,")
 
     app_driver$set_active_module_input("g_mmrm_lsmeans_select", "estimates")
@@ -221,7 +212,7 @@ testthat::test_that(
     app_driver$set_active_module_input("g_mmrm_lsmeans_contrasts_show_pval", TRUE)
     app_driver$expect_no_validation_error()
 
-    plot <- app_driver$get_active_module_pws_output("mmrm_plot")
+    plot <- app_driver$get_active_module_plot_output("mmrm_plot")
     testthat::expect_match(plot, "data:image/png;base64,")
 
     testthat::expect_false(identical(plot_before, plot))
@@ -230,10 +221,8 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_a_mmrm: function g_mmrm_diagnostic selection shows output settings; changing",
-    "settings throws no validation errors and verify visibility of generated plots."
-  ),
+  "e2e - tm_a_mmrm: Function g_mmrm_diagnostic selection shows output settings; changing
+  settings throws no validation errors and verify visibility of generated plots.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_a_mmrm()
@@ -244,13 +233,13 @@ testthat::test_that(
     app_driver$set_active_module_input("output_function", "g_mmrm_diagnostic", wait_ = FALSE)
     app_driver$expect_no_validation_error()
 
-    plot_before <- app_driver$get_active_module_pws_output("mmrm_plot")
+    plot_before <- app_driver$get_active_module_plot_output("mmrm_plot")
     testthat::expect_match(plot_before, "data:image/png;base64,")
 
     app_driver$set_active_module_input("g_mmrm_diagnostic_type", "q-q-residual")
     app_driver$expect_no_validation_error()
 
-    plot <- app_driver$get_active_module_pws_output("mmrm_plot")
+    plot <- app_driver$get_active_module_plot_output("mmrm_plot")
     testthat::expect_match(plot, "data:image/png;base64,")
 
     testthat::expect_false(identical(plot_before, plot))
@@ -260,8 +249,8 @@ testthat::test_that(
 
 for (func in output_functions) {
   testthat::test_that(
-    paste0(
-      "e2e - tm_a_mmrm: Deselection of aval_var throws validation error in method",
+    sprintf(
+      "e2e - tm_a_mmrm: Deselection of aval_var throws validation error in method %s.",
       func
     ),
     {
@@ -273,9 +262,9 @@ for (func in output_functions) {
 
       app_driver$set_active_module_input("aval_var-dataset_ADQS_singleextract-select", character(0L))
       if (grepl("^g_", func)) {
-        testthat::expect_identical(app_driver$get_active_module_pws_output("mmrm_plot"), character(0))
+        testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_tws_output("mmrm_table"), data.frame())
+        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
       }
 
       testthat::expect_match(
@@ -293,8 +282,8 @@ for (func in output_functions) {
   )
 
   testthat::test_that(
-    paste0(
-      "e2e - tm_a_mmrm: Deselection paramcd throws validation error in method",
+    sprintf(
+      "e2e - tm_a_mmrm: Deselection paramcd throws validation error in method %s.",
       func
     ),
     {
@@ -306,9 +295,9 @@ for (func in output_functions) {
 
       app_driver$set_active_module_input("paramcd-dataset_ADQS_singleextract-filter1-vals", character(0L))
       if (grepl("^g_", func)) {
-        testthat::expect_identical(app_driver$get_active_module_pws_output("mmrm_plot"), character(0))
+        testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_tws_output("mmrm_table"), data.frame())
+        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
       }
 
       testthat::expect_match(
@@ -326,8 +315,8 @@ for (func in output_functions) {
   )
 
   testthat::test_that(
-    paste0(
-      "e2e - tm_a_mmrm: Deselection of visit_var throws validation error in method",
+    sprintf(
+      "e2e - tm_a_mmrm: Deselection of visit_var throws validation error in method %s.",
       func
     ),
     {
@@ -339,9 +328,9 @@ for (func in output_functions) {
 
       app_driver$set_active_module_input("visit_var-dataset_ADQS_singleextract-select", character(0L))
       if (grepl("^g_", func)) {
-        testthat::expect_identical(app_driver$get_active_module_pws_output("mmrm_plot"), character(0))
+        testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_tws_output("mmrm_table"), data.frame())
+        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
       }
 
       testthat::expect_match(
@@ -359,8 +348,8 @@ for (func in output_functions) {
   )
 
   testthat::test_that(
-    paste0(
-      "e2e - tm_a_mmrm: Deselection of arm_var throws validation error in method",
+    sprintf(
+      "e2e - tm_a_mmrm: Deselection of arm_var throws validation error in method %s.",
       func
     ),
     {
@@ -372,9 +361,9 @@ for (func in output_functions) {
 
       app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", character(0L))
       if (grepl("^g_", func)) {
-        testthat::expect_identical(app_driver$get_active_module_pws_output("mmrm_plot"), character(0))
+        testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_tws_output("mmrm_table"), data.frame())
+        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
       }
 
       testthat::expect_match(
@@ -392,8 +381,8 @@ for (func in output_functions) {
   )
 
   testthat::test_that(
-    paste0(
-      "e2e - tm_a_mmrm: Deselection of id_var throws validation error in method",
+    sprintf(
+      "e2e - tm_a_mmrm: Deselection of id_var throws validation error in method %s.",
       func
     ),
     {
@@ -405,9 +394,9 @@ for (func in output_functions) {
 
       app_driver$set_active_module_input("id_var-dataset_ADQS_singleextract-select", character(0L))
       if (grepl("^g_", func)) {
-        testthat::expect_identical(app_driver$get_active_module_pws_output("mmrm_plot"), character(0))
+        testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_tws_output("mmrm_table"), data.frame())
+        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
       }
 
       testthat::expect_match(
@@ -425,8 +414,8 @@ for (func in output_functions) {
   )
 
   testthat::test_that(
-    paste0(
-      "e2e - tm_a_mmrm: Deselection of conf_level throws validation error in method",
+    sprintf(
+      "e2e - tm_a_mmrm: Deselection of conf_level throws validation error in method %s.",
       func
     ),
     {
@@ -438,9 +427,9 @@ for (func in output_functions) {
 
       app_driver$set_active_module_input("conf_level", numeric(0L))
       if (grepl("^g_", func)) {
-        testthat::expect_identical(app_driver$get_active_module_pws_output("mmrm_plot"), character(0))
+        testthat::expect_identical(app_driver$get_active_module_plot_output("mmrm_plot"), character(0))
       } else {
-        testthat::expect_identical(app_driver$get_active_module_tws_output("mmrm_table"), data.frame())
+        testthat::expect_identical(app_driver$get_active_module_table_output("mmrm_table-table-with-settings"), data.frame())
       }
 
       testthat::expect_match(
@@ -489,49 +478,54 @@ non_responsive_conditions <- list(
 
 # Iterate over each output function
 for (func in output_functions) {
-  testthat::test_that(paste0("e2e - tm_a_mmrm: Validate output on different selection on method ", func), {
-    skip_if_too_deep(5)
-    app_driver <- app_driver_tm_a_mmrm()
-    # Set initial output function
-    app_driver$set_active_module_input("output_function", func, wait_ = FALSE)
-    app_driver$expect_no_validation_error()
-
-
-    if (grepl("^g_", func)) {
-      plot_before <- app_driver$get_active_module_pws_output("mmrm_plot")
-    } else {
-      table_before <- app_driver$get_active_module_tws_output("mmrm_table")
-    }
-
-    # Iterate over each input and test changes
-    for (input_name in names(input_list)) {
-      if (input_name %in% non_responsive_conditions[[func]]) {
-        next
-      }
-
-      app_driver$set_active_module_input(input_name, input_list[[input_name]])
-      app_driver$click(selector = app_driver$active_module_element("button_start"))
+  testthat::test_that(
+    sprintf(
+      "e2e - tm_a_mmrm: Validate output on different selection on method %s.",
+      func
+    ),
+    {
+      skip_if_too_deep(5)
+      app_driver <- app_driver_tm_a_mmrm()
+      # Set initial output function
+      app_driver$set_active_module_input("output_function", func, wait_ = FALSE)
       app_driver$expect_no_validation_error()
 
-      # Check output based on function type (plot or table)
+
       if (grepl("^g_", func)) {
-        testthat::expect_false(
-          identical(
-            plot_before,
-            app_driver$get_active_module_pws_output("mmrm_plot")
-          ),
-          info = print(paste(func, "===", input_name))
-        )
-        plot_before <- app_driver$get_active_module_pws_output("mmrm_plot")
+        plot_before <- app_driver$get_active_module_plot_output("mmrm_plot")
       } else {
-        testthat::expect_false(
-          identical(
-            table_before,
-            app_driver$get_active_module_tws_output("mmrm_table")
-          )
-        )
+        table_before <- app_driver$get_active_module_table_output("mmrm_table-table-with-settings")
       }
+
+      # Iterate over each input and test changes
+      for (input_name in names(input_list)) {
+        if (input_name %in% non_responsive_conditions[[func]]) {
+          next
+        }
+
+        app_driver$set_active_module_input(input_name, input_list[[input_name]])
+        app_driver$click(selector = app_driver$active_module_element("button_start"))
+        app_driver$expect_no_validation_error()
+
+        # Check output based on function type (plot or table)
+        if (grepl("^g_", func)) {
+          testthat::expect_false(
+            identical(
+              plot_before,
+              app_driver$get_active_module_plot_output("mmrm_plot")
+            )
+          )
+          plot_before <- app_driver$get_active_module_plot_output("mmrm_plot")
+        } else {
+          testthat::expect_false(
+            identical(
+              table_before,
+              app_driver$get_active_module_table_output("mmrm_table-table-with-settings")
+            )
+          )
+        }
+      }
+      app_driver$stop()
     }
-    app_driver$stop()
-  })
+  )
 }

--- a/tests/testthat/test-shinytest2-tm_g_barchart_simple.R
+++ b/tests/testthat/test-shinytest2-tm_g_barchart_simple.R
@@ -130,10 +130,8 @@ testthat::test_that("e2e - tm_g_barchart_simple: Module initializes in teal with
 })
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_g_barchart_simple: Starts with specified ",
-    "label, id_var, arm_var, visit_var, paramcd, cov_var, conf_level and conf_struct."
-  ),
+  "e2e - tm_g_barchart_simple: Starts with specified label, id_var, arm_var, visit_var,
+  paramcd, cov_var, conf_level and conf_struct.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_barchart_simple()
@@ -193,13 +191,13 @@ testthat::test_that(
 # X-variable ------------------------------------------------------------------
 
 testthat::test_that(
-  "e2e - tm_g_barchart_simple: Selection of 'x' changes the element and does not throw validation errors",
+  "e2e - tm_g_barchart_simple: Selection of 'x' changes the element and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_barchart_simple()
-    plot_before <- app_driver$get_active_module_pws_output("myplot")
+    plot_before <- app_driver$get_active_module_plot_output("myplot")
     app_driver$set_active_module_input(ns_des_input("x", "ADSL", "select"), "RACE")
-    testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+    testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -227,15 +225,15 @@ testthat::test_that("e2e - tm_g_barchart_simple: Deselection of 'x' throws valid
 test_dataset_selection <- function(input_id, new_dataset, new_value) {
   testthat::test_that(
     sprintf(
-      "e2e - tm_g_barchart_simple: Selection of '%s' dataset changes the element and does not throw validation errors",
+      "e2e - tm_g_barchart_simple: Selection of '%s' dataset changes the element and does not throw validation errors.",
       input_id
     ),
     {
       skip_if_too_deep(5)
       app_driver <- app_driver_tm_g_barchart_simple()
-      plot_before <- app_driver$get_active_module_pws_output("myplot")
+      plot_before <- app_driver$get_active_module_plot_output("myplot")
       app_driver$set_active_module_input(sprintf("%s-dataset", input_id), new_dataset)
-      testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+      testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
       testthat::expect_null(app_driver$get_active_module_input(ns_des_input(input_id, new_dataset, "select")))
       app_driver$set_active_module_input(ns_des_input(input_id, new_dataset, "select"), new_value)
       testthat::expect_identical(
@@ -249,17 +247,17 @@ test_dataset_selection <- function(input_id, new_dataset, new_value) {
 
   testthat::test_that(
     sprintf(
-      "%s: De-selection of '%s' dataset changes the element and does not throw validation errors",
+      "%s: Deselection of '%s' dataset changes the element and does not throw validation errors.",
       "e2e - tm_g_barchart_simple",
       input_id
     ),
     {
       skip_if_too_deep(5)
       app_driver <- app_driver_tm_g_barchart_simple()
-      plot_before <- app_driver$get_active_module_pws_output("myplot")
+      plot_before <- app_driver$get_active_module_plot_output("myplot")
       app_driver$set_active_module_input(sprintf("%s-dataset", input_id), character(0L))
       testthat::expect_null(app_driver$get_active_module_input(input_id))
-      testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+      testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
       app_driver$expect_no_validation_error()
       app_driver$stop()
     }
@@ -275,7 +273,7 @@ test_dataset_selection("y_facet", "ADSL", "ARM")
 for (input_id in c("fill", "x_facet", "y_facet")) {
   testthat::test_that(
     sprintf(
-      "e2e - tm_g_barchart_simple: Duplicate between 'x' and '%s' selection throws validation error",
+      "e2e - tm_g_barchart_simple: Duplicate between 'x' and '%s' selection throws validation error.",
       input_id
     ),
     {
@@ -306,6 +304,7 @@ for (input_id in c("fill", "x_facet", "y_facet")) {
         ),
         "^Duplicated value: ACTARM$"
       )
+      app_driver$stop()
     }
   )
 }
@@ -322,9 +321,9 @@ test_that_plot_settings <- function(input_id, new_value, setup_fun = function(ap
       skip_if_too_deep(5)
       app_driver <- app_driver_tm_g_barchart_simple()
       setup_fun(app_driver)
-      plot_before <- app_driver$get_active_module_pws_output("myplot")
+      plot_before <- app_driver$get_active_module_plot_output("myplot")
       app_driver$set_active_module_input(input_id, new_value)
-      testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+      testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
       app_driver$expect_no_validation_error()
       app_driver$stop()
     }

--- a/tests/testthat/test-shinytest2-tm_g_ci.R
+++ b/tests/testthat/test-shinytest2-tm_g_ci.R
@@ -57,17 +57,26 @@ app_driver_tm_g_ci <- function() {
           multiple = FALSE,
           fixed = FALSE
         )
-      )
+      ),
+      stat = c("mean", "median"),
+      conf_level = teal.transform::choices_selected(c(0.95, 0.9, 0.8), 0.95,
+        keep_order = TRUE
+      ),
+      plot_height = c(700L, 200L, 2000L),
+      plot_width = NULL,
+      pre_output = NULL,
+      post_output = NULL,
+      ggplot2_args = teal.widgets::ggplot2_args()
     )
   )
 }
 
-testthat::test_that("e2e - tm_g_ci: example ci module initializes in teal without errors and produces plot output.", {
+testthat::test_that("e2e - tm_g_ci: Module initializes in teal without errors and produces plot output.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
   app_driver$expect_no_shiny_error()
   app_driver$expect_no_validation_error()
-  testthat::expect_match(app_driver$get_active_module_pws_output("myplot"), "data:image/png;base64,")
+  testthat::expect_match(app_driver$get_active_module_plot_output("myplot"), "data:image/png;base64,")
   app_driver$stop()
 })
 
@@ -131,12 +140,12 @@ testthat::test_that(
 testthat::test_that("e2e - tm_g_ci: Selecting x_var column changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("x_var-dataset_ADSL_singleextract-select", "BMRKR2")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -147,7 +156,7 @@ testthat::test_that("e2e - tm_g_ci: Deselecting x_var column throws validation e
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
   app_driver$set_active_module_input("x_var-dataset_ADSL_singleextract-select", character(0))
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   app_driver$expect_validation_error()
   testthat::expect_identical(
     app_driver$active_module_element_text("x_var-dataset_ADSL_singleextract-select_input > div > span"),
@@ -159,12 +168,12 @@ testthat::test_that("e2e - tm_g_ci: Deselecting x_var column throws validation e
 testthat::test_that("e2e - tm_g_ci: Selecting y_var column changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("y_var-dataset_ADLB_singleextract-select", "CHG2")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -175,7 +184,7 @@ testthat::test_that("e2e - tm_g_ci: Deselecting y_var column throws validation e
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
   app_driver$set_active_module_input("y_var-dataset_ADLB_singleextract-select", character(0))
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("y_var-dataset_ADLB_singleextract-select_input > div > span"),
     "Select an analysis value (y axis)"
@@ -189,12 +198,12 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_ci()
-    plot_before <- app_driver$get_active_module_pws_output("myplot")
+    plot_before <- app_driver$get_active_module_plot_output("myplot")
     app_driver$set_active_module_input("y_var-dataset_ADLB_singleextract-filter1-vals", "CRP")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("myplot")
+        app_driver$get_active_module_plot_output("myplot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -206,7 +215,7 @@ testthat::test_that("e2e - tm_g_ci: Deselecting PARAMCD filter value throws vali
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
   app_driver$set_active_module_input("y_var-dataset_ADLB_singleextract-filter1-vals", character(0))
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("y_var-dataset_ADLB_singleextract-filter1-vals_input > div > span"),
     "Please select the filters."
@@ -218,9 +227,9 @@ testthat::test_that("e2e - tm_g_ci: Deselecting PARAMCD filter value throws vali
 testthat::test_that("e2e - tm_g_ci: Selecting AVISIT filter value doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("y_var-dataset_ADLB_singleextract-filter2-vals", "BASELINE")
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -229,7 +238,7 @@ testthat::test_that("e2e - tm_g_ci: Deselecting AVISIT filter value throws valid
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
   app_driver$set_active_module_input("y_var-dataset_ADLB_singleextract-filter2-vals", character(0))
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("y_var-dataset_ADLB_singleextract-filter2-vals_input > div > span"),
     "Please select the filters."
@@ -241,9 +250,9 @@ testthat::test_that("e2e - tm_g_ci: Deselecting AVISIT filter value throws valid
 testthat::test_that("e2e - tm_g_ci: Selecting color column changes plot output and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("color-dataset_ADSL_singleextract-select", "SEX")
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -251,9 +260,9 @@ testthat::test_that("e2e - tm_g_ci: Selecting color column changes plot output a
 testthat::test_that("e2e - tm_g_ci: Deselecting color column changes plot output and doesn't throw validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("color-dataset_ADSL_singleextract-select", character(0))
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -261,9 +270,9 @@ testthat::test_that("e2e - tm_g_ci: Deselecting color column changes plot output
 testthat::test_that("e2e - tm_g_ci: Selecting confidence interval value changes plot and doesn't throw any errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("conf_level", 0.90)
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -272,9 +281,9 @@ testthat::test_that("e2e - tm_g_ci: Selecting confidence interval value changes 
 testthat::test_that("e2e - tm_g_ci: Selecting statistic to use changes a plot and doesn't throw any errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ci()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("stat", "median")
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })

--- a/tests/testthat/test-shinytest2-tm_g_forest_rsp.R
+++ b/tests/testthat/test-shinytest2-tm_g_forest_rsp.R
@@ -31,6 +31,7 @@ app_driver_tm_g_forest_rsp <- function() {
       tm_g_forest_rsp(
         label = "Forest Response",
         dataname = "ADRS",
+        parentname = "ADSL",
         arm_var = teal.transform::choices_selected(
           teal.transform::variable_choices(data[["ADSL"]], c("ARM", "ARMCD")),
           "ARMCD"
@@ -40,6 +41,11 @@ app_driver_tm_g_forest_rsp <- function() {
           teal.transform::value_choices(data[["ADRS"]], "PARAMCD", "PARAM"),
           "INVET"
         ),
+        aval_var = teal.transform::choices_selected(
+          teal.transform::variable_choices(data[["ADRS"]], "AVALC"),
+          "AVALC",
+          fixed = TRUE
+        ),
         subgroup_var = teal.transform::choices_selected(
           teal.transform::variable_choices(data[["ADSL"]], names(data[["ADSL"]])),
           c("BMRKR2", "SEX")
@@ -48,6 +54,7 @@ app_driver_tm_g_forest_rsp <- function() {
           teal.transform::variable_choices(data[["ADSL"]], c("STRATA1", "STRATA2")),
           "STRATA2"
         ),
+        fixed_symbol_size = TRUE,
         conf_level = teal.transform::choices_selected(c(0.95, 0.9, 0.8, 2), 0.95, keep_order = TRUE),
         plot_height = c(600L, 200L, 2000L),
         default_responses = list(
@@ -69,7 +76,13 @@ app_driver_tm_g_forest_rsp <- function() {
             rsp = c("Progressive Disease (PD)", "Stable Disease (SD)"),
             levels = c("Progressive Disease (PD)", "Stable Disease (SD)", "Not Evaluable (NE)")
           )
-        )
+        ),
+        plot_width = c(1500L, 800L, 3000L),
+        rel_width_forest = c(25L, 0L, 100L),
+        font_size = c(15L, 1L, 30L),
+        pre_output = NULL,
+        post_output = NULL,
+        ggplot2_args = teal.widgets::ggplot2_args()
       )
     )
   )
@@ -149,9 +162,9 @@ testthat::test_that(
 testthat::test_that("e2e - tm_g_forest_rsp: Selecting arm_var changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_forest_rsp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARM")
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -171,9 +184,9 @@ testthat::test_that("e2e - tm_g_forest_rsp: Deselecting arm_var throws validatio
 testthat::test_that("e2e - tm_g_forest_rsp: Selecting paramcd changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_forest_rsp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("paramcd-dataset_ADRS_singleextract-filter1-vals", "OVRINV")
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -193,9 +206,9 @@ testthat::test_that("e2e - tm_g_forest_rsp: Deselecting paramcd throws validatio
 testthat::test_that("e2e - tm_g_forest_rsp: Selecting responders changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_forest_rsp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("responders", "Complete Response (CR)")
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -215,9 +228,9 @@ testthat::test_that("e2e - tm_g_forest_rsp: Deselecting responders throws valida
 testthat::test_that("e2e - tm_g_forest_rsp: Selecting subgroup_var changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_forest_rsp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("subgroup_var-dataset_ADSL_singleextract-select", c("SEX", "BMRKR2", "AGEU"))
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -237,9 +250,9 @@ testthat::test_that("e2e - tm_g_forest_rsp: Selecting a non-factors column in su
 testthat::test_that("e2e - tm_g_forest_rsp: Deselecting subgroup_var changes plot and doesn't throw validation errors.", { # nolint: line_length
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_forest_rsp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("subgroup_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -247,9 +260,9 @@ testthat::test_that("e2e - tm_g_forest_rsp: Deselecting subgroup_var changes plo
 testthat::test_that("e2e - tm_g_forest_rsp: Selecting strata_var changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_forest_rsp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", "STRATA1")
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -257,9 +270,9 @@ testthat::test_that("e2e - tm_g_forest_rsp: Selecting strata_var changes plot an
 testthat::test_that("e2e - tm_g_forest_rsp: Deselecting strata_var changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_forest_rsp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -267,9 +280,9 @@ testthat::test_that("e2e - tm_g_forest_rsp: Deselecting strata_var changes plot 
 testthat::test_that("e2e - tm_g_forest_rsp: Selecting conf_level changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_forest_rsp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("conf_level", "0.9")
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -295,9 +308,9 @@ testthat::test_that("e2e - tm_g_forest_rsp: Deselecting conf_level or selecting 
 testthat::test_that("e2e - tm_g_forest_rsp: Unsetting fixed_symbol_size changes plot and doesn't throw validation errors.", { # nolint: line_length
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_forest_rsp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("fixed_symbol_size", FALSE)
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -305,9 +318,9 @@ testthat::test_that("e2e - tm_g_forest_rsp: Unsetting fixed_symbol_size changes 
 testthat::test_that("e2e - tm_g_forest_rsp: Changing rel_width_forest changes plot and doesn't throw validation errors.", { # nolint: line_length
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_forest_rsp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("rel_width_forest", 30)
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -315,9 +328,9 @@ testthat::test_that("e2e - tm_g_forest_rsp: Changing rel_width_forest changes pl
 testthat::test_that("e2e - tm_g_forest_rsp: Changing font_size changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_forest_rsp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("font_size", 25)
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })

--- a/tests/testthat/test-shinytest2-tm_g_forest_tte.R
+++ b/tests/testthat/test-shinytest2-tm_g_forest_tte.R
@@ -210,22 +210,6 @@ testthat::test_that("e2e - tm_g_forest_tte: Deselection of paramcd var throws va
 })
 
 testthat::test_that(
-  "e2e - tm_g_forest_tte: Selecting aval_var does not throw validation errors and changes a plot.",
-  {
-    skip_if_too_deep(5)
-    testthat::skip("Not possible in this app due to fixed input.")
-  }
-)
-
-testthat::test_that(
-  "e2e - tm_g_forest_tte: Selecting time_unit variable does not throw validation errors and changes a plot.",
-  {
-    skip_if_too_deep(5)
-    testthat::skip("Not possible in this app due to fixed input.")
-  }
-)
-
-testthat::test_that(
   "e2e - tm_g_forest_tte: Selecting conf_level does not throw validation errors and changes a plot.",
   {
     skip_if_too_deep(5)

--- a/tests/testthat/test-shinytest2-tm_g_forest_tte.R
+++ b/tests/testthat/test-shinytest2-tm_g_forest_tte.R
@@ -25,6 +25,7 @@ app_driver_tm_g_forest_tte <- function() { # nolint: object_length.
     modules = tm_g_forest_tte(
       label = "Forest Survival (e2e)",
       dataname = "ADTTE",
+      parentname = "ADSL",
       arm_var = teal.transform::choices_selected(
         teal.transform::variable_choices(data[["ADSL"]], c("ARM", "ARMCD")),
         "ARMCD"
@@ -41,6 +42,25 @@ app_driver_tm_g_forest_tte <- function() { # nolint: object_length.
       strata_var = teal.transform::choices_selected(
         teal.transform::variable_choices(data[["ADSL"]], c("STRATA1", "STRATA2")),
         "STRATA2"
+      ),
+      aval_var = teal.transform::choices_selected(
+        teal.transform::variable_choices(data[["ADTTE"]], "AVAL"),
+        "AVAL",
+        fixed = TRUE
+      ),
+      cnsr_var = teal.transform::choices_selected(
+        teal.transform::variable_choices(data[["ADTTE"]], "CNSR"),
+        "CNSR",
+        fixed = TRUE
+      ),
+      conf_level = teal.transform::choices_selected(
+        c(0.95, 0.9, 0.8), 0.95,
+        keep_order = TRUE
+      ),
+      time_unit_var = teal.transform::choices_selected(
+        teal.transform::variable_choices(data[["ADTTE"]], "AVALU"),
+        "AVALU",
+        fixed = TRUE
       ),
       fixed_symbol_size = FALSE,
       plot_height = c(500L, 300L, 2000L),
@@ -69,10 +89,8 @@ testthat::test_that("e2e - tm_g_forest_tte: Module initializes in teal without e
 })
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_g_forest_tte: Starts with specified ",
-    "label, paramcd, arm_var, buckets, paramcd, subgroup_var, strata_var and plot settings"
-  ),
+  "e2e - tm_g_forest_tte: Starts with specified label, paramcd, arm_var, buckets,
+    paramcd, subgroup_var, strata_var and plot settings.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_forest_tte()
@@ -130,13 +148,13 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_g_forest_tte: Selection of 'paramcd' changes the element and does not throw validation errors",
+  "e2e - tm_g_forest_tte: Selection of 'paramcd' changes the element and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_forest_tte()
-    plot_before <- app_driver$get_active_module_pws_output("myplot")
+    plot_before <- app_driver$get_active_module_plot_output("myplot")
     app_driver$set_active_module_input(ns_des_input("paramcd", "ADTTE", "filter1-vals"), "CRSD")
-    testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+    testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -161,13 +179,13 @@ testthat::test_that("e2e - tm_g_forest_tte: Deselection of paramcd filter throws
 })
 
 testthat::test_that(
-  "e2e - tm_g_forest_tte: Selection of 'arm_var' changes the element and does not throw validation errors",
+  "e2e - tm_g_forest_tte: Selection of 'arm_var' changes the element and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_forest_tte()
-    plot_before <- app_driver$get_active_module_pws_output("myplot")
+    plot_before <- app_driver$get_active_module_plot_output("myplot")
     app_driver$set_active_module_input(ns_des_input("arm_var", "ADSL", "select"), "ARM")
-    testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+    testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -195,7 +213,7 @@ testthat::test_that(
   "e2e - tm_g_forest_tte: Selecting aval_var does not throw validation errors and changes a plot.",
   {
     skip_if_too_deep(5)
-    # not possible in this app due to fixed input
+    testthat::skip("Not possible in this app due to fixed input.")
   }
 )
 
@@ -203,7 +221,7 @@ testthat::test_that(
   "e2e - tm_g_forest_tte: Deselecting aval_var throws validation error.",
   {
     skip_if_too_deep(5)
-    # not possible in this app due to fixed input
+    testthat::skip("Not possible in this app due to fixed input.")
   }
 )
 
@@ -211,7 +229,7 @@ testthat::test_that(
   "e2e - tm_g_forest_tte: Selecting cnsr_var does not throw validation errors and changes a plot.",
   {
     skip_if_too_deep(5)
-    # not possible in this app due to fixed input
+    testthat::skip("Not possible in this app due to fixed input.")
   }
 )
 
@@ -219,7 +237,7 @@ testthat::test_that(
   "e2e - tm_g_forest_tte: Deselecting cnsr_var throws validation error.",
   {
     skip_if_too_deep(5)
-    # not possible in this app due to fixed input
+    testthat::skip("Not possible in this app due to fixed input.")
   }
 )
 
@@ -227,7 +245,7 @@ testthat::test_that(
   "e2e - tm_g_forest_tte: Selecting time_unit variable does not throw validation errors and changes a plot.",
   {
     skip_if_too_deep(5)
-    # not possible in this app due to fixed input
+    testthat::skip("Not possible in this app due to fixed input.")
   }
 )
 
@@ -237,9 +255,9 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_forest_tte()
     input_id <- "conf_level"
-    plot_before <- app_driver$get_active_module_pws_output("myplot")
+    plot_before <- app_driver$get_active_module_plot_output("myplot")
     app_driver$set_active_module_input(input_id, "0.99")
-    testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+    testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
     app_driver$expect_validation_error()
     testthat::expect_match(
       app_driver$active_module_element_text(

--- a/tests/testthat/test-shinytest2-tm_g_forest_tte.R
+++ b/tests/testthat/test-shinytest2-tm_g_forest_tte.R
@@ -218,30 +218,6 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_g_forest_tte: Deselecting aval_var throws validation error.",
-  {
-    skip_if_too_deep(5)
-    testthat::skip("Not possible in this app due to fixed input.")
-  }
-)
-
-testthat::test_that(
-  "e2e - tm_g_forest_tte: Selecting cnsr_var does not throw validation errors and changes a plot.",
-  {
-    skip_if_too_deep(5)
-    testthat::skip("Not possible in this app due to fixed input.")
-  }
-)
-
-testthat::test_that(
-  "e2e - tm_g_forest_tte: Deselecting cnsr_var throws validation error.",
-  {
-    skip_if_too_deep(5)
-    testthat::skip("Not possible in this app due to fixed input.")
-  }
-)
-
-testthat::test_that(
   "e2e - tm_g_forest_tte: Selecting time_unit variable does not throw validation errors and changes a plot.",
   {
     skip_if_too_deep(5)

--- a/tests/testthat/test-shinytest2-tm_g_ipp.R
+++ b/tests/testthat/test-shinytest2-tm_g_ipp.R
@@ -21,6 +21,7 @@ app_driver_tm_g_ipp <- function() {
     modules = tm_g_ipp(
       label = "Individual Patient Plot",
       dataname = "ADLB",
+      parentname = "ADSL",
       arm_var = teal.transform::choices_selected(
         teal.transform::value_choices(data[["ADLB"]], "ARMCD"),
         "ARM A"
@@ -53,7 +54,14 @@ app_driver_tm_g_ipp <- function() {
         fixed = TRUE
       ),
       add_baseline_hline = FALSE,
-      separate_by_obs = FALSE
+      separate_by_obs = FALSE,
+      suppress_legend = FALSE,
+      add_avalu = TRUE,
+      plot_height = c(1200L, 400L, 5000L),
+      plot_width = NULL,
+      pre_output = NULL,
+      post_output = NULL,
+      ggplot2_args = teal.widgets::ggplot2_args()
     )
   )
 }
@@ -64,7 +72,7 @@ testthat::test_that("e2e - tm_g_ipp: Module initializes in teal without errors a
   app_driver$expect_no_shiny_error()
   app_driver$expect_no_validation_error()
   testthat::expect_match(
-    app_driver$get_active_module_pws_output("myplot"),
+    app_driver$get_active_module_plot_output("myplot"),
     "data:image/png;base64,"
   )
   app_driver$stop()
@@ -128,12 +136,12 @@ testthat::test_that(
 testthat::test_that("e2e - tm_g_ipp: Selecting arm_var changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-filter1-vals", "ARM B")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -144,7 +152,7 @@ testthat::test_that("e2e - tm_g_ipp: Deselecting arm_var column throws validatio
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-filter1-vals_input > div > span"),
     "Please select Arm filter."
@@ -156,12 +164,12 @@ testthat::test_that("e2e - tm_g_ipp: Deselecting arm_var column throws validatio
 testthat::test_that("e2e - tm_g_ipp: Selecting paramcd changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-filter1-vals", "CRP")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -172,7 +180,7 @@ testthat::test_that("e2e - tm_g_ipp: Deselecting paramcd throws validation error
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
   app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("paramcd-dataset_ADLB_singleextract-filter1-vals_input > div > span"),
     "Please select Parameter filter."
@@ -184,12 +192,12 @@ testthat::test_that("e2e - tm_g_ipp: Deselecting paramcd throws validation error
 testthat::test_that("e2e - tm_g_ipp: Selecting visit_var changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("visit_var-dataset_ADLB_singleextract-select", "ATOXGR")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -200,7 +208,7 @@ testthat::test_that("e2e - tm_g_ipp: Deselecting visit_var throws validation err
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
   app_driver$set_active_module_input("visit_var-dataset_ADLB_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("visit_var-dataset_ADLB_singleextract-select_input > div > span"),
     "A Timepoint Variable must be selected"
@@ -212,12 +220,12 @@ testthat::test_that("e2e - tm_g_ipp: Deselecting visit_var throws validation err
 testthat::test_that("e2e - tm_g_ipp: Selecting aval_var changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("aval_var-dataset_ADLB_singleextract-select", "CHG")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -228,7 +236,7 @@ testthat::test_that("e2e - tm_g_ipp: Deselecting aval_var throws validation erro
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
   app_driver$set_active_module_input("aval_var-dataset_ADLB_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("aval_var-dataset_ADLB_singleextract-select_input > div > span"),
     "A Parameter values over Time must be selected"
@@ -240,12 +248,12 @@ testthat::test_that("e2e - tm_g_ipp: Deselecting aval_var throws validation erro
 testthat::test_that("e2e - tm_g_ipp: Changing add_baseline_hline changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("add_baseline_hline", TRUE)
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -254,12 +262,12 @@ testthat::test_that("e2e - tm_g_ipp: Changing add_baseline_hline changes plot an
 testthat::test_that("e2e - tm_g_ipp: Changing separate_by_obs changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("separate_by_obs", TRUE)
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -269,12 +277,12 @@ testthat::test_that("e2e - tm_g_ipp: Changing separate_by_obs changes plot and d
 testthat::test_that("e2e - tm_g_ipp: Changing suppress_legend changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("suppress_legend", TRUE)
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -284,12 +292,12 @@ testthat::test_that("e2e - tm_g_ipp: Changing suppress_legend changes plot and d
 testthat::test_that("e2e - tm_g_ipp: Changing add_avalu changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_ipp()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("add_avalu", FALSE)
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()

--- a/tests/testthat/test-shinytest2-tm_g_km.R
+++ b/tests/testthat/test-shinytest2-tm_g_km.R
@@ -31,6 +31,7 @@ app_driver_tm_g_km <- function() {
     modules = tm_g_km(
       label = "Kaplan-Meier Plot",
       dataname = "ADTTE",
+      parentname = "ADSL",
       arm_var = teal.transform::choices_selected(
         teal.transform::variable_choices(data[["ADSL"]], c("ARM", "ARMCD", "ACTARMCD")),
         "ARM"
@@ -63,7 +64,16 @@ app_driver_tm_g_km <- function() {
         "CENSORING",
         fixed = TRUE
       ),
-      conf_level = teal.transform::choices_selected(c(0.95, 0.9, 0.8, -1), 0.95, keep_order = TRUE)
+      conf_level = teal.transform::choices_selected(c(0.95, 0.9, 0.8, -1), 0.95, keep_order = TRUE),
+      font_size = c(11L, 1L, 30),
+      control_annot_surv_med = control_surv_med_annot(),
+      control_annot_coxph = control_coxph_annot(x = 0.27, y = 0.35, w = 0.3),
+      legend_pos = c(0.9, 0.5),
+      rel_height_plot = c(80L, 0L, 100L),
+      plot_height = c(800L, 400L, 5000L),
+      plot_width = NULL,
+      pre_output = NULL,
+      post_output = NULL
     )
   )
 }
@@ -75,7 +85,7 @@ testthat::test_that("e2e - tm_g_km: Module initializes in teal without errors an
   app_driver$expect_no_validation_error()
 
   testthat::expect_match(
-    app_driver$get_active_module_pws_output("myplot"),
+    app_driver$get_active_module_plot_output("myplot"),
     "data:image/png;base64,"
   )
   app_driver$stop()
@@ -129,50 +139,50 @@ testthat::test_that(
 testthat::test_that("e2e - tm_g_km: Changing {paramcd} changes the plot without errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_km()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("paramcd-dataset_ADTTE_singleextract-filter1-vals", "EFS")
   app_driver$expect_no_validation_error()
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$stop()
 })
 
 testthat::test_that("e2e - tm_g_km: Changing {facet_var} changes the plot without errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_km()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input(ns_des_input("facet_var", "ADSL", "select"), "SEX")
   app_driver$expect_no_validation_error()
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$stop()
 })
 
 testthat::test_that("e2e - tm_g_km: Changing {arm_var} changes the plot without errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_km()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input(ns_des_input("arm_var", "ADSL", "select"), "ACTARMCD")
   app_driver$expect_no_validation_error()
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$stop()
 })
 
 testthat::test_that("e2e - tm_g_km: Changing {compare_arms} changes the plot without errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_km()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("compare_arms", FALSE)
   app_driver$expect_no_validation_error()
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$stop()
 })
 
 testthat::test_that("e2e - tm_g_km: Changing {strata_var} changes the plot without errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_km()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input(ns_des_input("strata_var", "ADSL", "select"), "BMRKR2")
   app_driver$expect_no_validation_error()
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$stop()
 })
 
@@ -270,20 +280,20 @@ testthat::test_that("e2e - tm_g_km: Starts with specified collapsed comparison s
 testthat::test_that("e2e - tm_g_km: Changing {pval_method_coxph} changes the plot without errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_km()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("pval_method_coxph", "wald")
   app_driver$expect_no_validation_error()
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$stop()
 })
 
 testthat::test_that("e2e - tm_g_km: Changing {ties_coxph} changes the plot without errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_km()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("ties_coxph", "breslow")
   app_driver$expect_no_validation_error()
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
   app_driver$stop()
 })
 
@@ -348,9 +358,9 @@ test_that_plot_settings <- function(input_id, new_value) {
     {
       skip_if_too_deep(5)
       app_driver <- app_driver_tm_g_km()
-      plot_before <- app_driver$get_active_module_pws_output("myplot")
+      plot_before <- app_driver$get_active_module_plot_output("myplot")
       app_driver$set_active_module_input(input_id, new_value)
-      testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("myplot")))
+      testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("myplot")))
       app_driver$expect_no_validation_error()
       app_driver$stop()
     }

--- a/tests/testthat/test-shinytest2-tm_g_lineplot.R
+++ b/tests/testthat/test-shinytest2-tm_g_lineplot.R
@@ -18,6 +18,7 @@ app_driver_tm_g_lineplot <- function() {
     modules = tm_g_lineplot(
       label = "Line Plot",
       dataname = "ADLB",
+      parentname = "ADSL",
       strata = teal.transform::choices_selected(
         teal.transform::variable_choices("ADSL", c("ARM", "ARMCD", "ACTARMCD")),
         "ARM"
@@ -78,11 +79,8 @@ testthat::test_that("e2e - tm_g_lineplot: Module initializes in teal without err
 })
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_g_lineplot: Starts with specified",
-    "label, param, strata, y-variable, x-variable, mid, interval, incl_screen",
-    "plot_settings and table_settings"
-  ),
+  "e2e - tm_g_lineplot: Starts with specified label, param, strata, y, x, mid, interval, incl_screen,
+    plot_settings and table_settings.",
   {
     skip_if_too_deep(5)
 
@@ -113,26 +111,26 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_g_lineplot: Selecting param-level changes plot and doesn't throw validation errors.", {
+testthat::test_that("e2e - tm_g_lineplot: Selecting param changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_lineplot()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("param-dataset_ADLB_singleextract-filter1-vals", "CRP")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
 
-testthat::test_that("e2e - tm_g_lineplot: Deselecting param-level throws validation error.", {
+testthat::test_that("e2e - tm_g_lineplot: Deselecting param throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_lineplot()
   app_driver$set_active_module_input("param-dataset_ADLB_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("param-dataset_ADLB_singleextract-filter1-vals_input > div > span"),
     "Please select Biomarker filter."
@@ -142,19 +140,16 @@ testthat::test_that("e2e - tm_g_lineplot: Deselecting param-level throws validat
 })
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_g_lineplot: Selecting strata-variable changes plot",
-    "and doesn't throw validation errors."
-  ),
+  "e2e - tm_g_lineplot: Selecting strata changes plot and doesn't throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_lineplot()
-    plot_before <- app_driver$get_active_module_pws_output("myplot")
+    plot_before <- app_driver$get_active_module_plot_output("myplot")
     app_driver$set_active_module_input("strata-dataset_ADSL_singleextract-select", "ARMCD")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("myplot")
+        app_driver$get_active_module_plot_output("myplot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -162,11 +157,11 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_g_lineplot: Deselecting strata-variable throws validation error.", {
+testthat::test_that("e2e - tm_g_lineplot: Deselecting strata throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_lineplot()
   app_driver$set_active_module_input("strata-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text(
       "strata-dataset_ADSL_singleextract-select_input > div > span"
@@ -177,26 +172,26 @@ testthat::test_that("e2e - tm_g_lineplot: Deselecting strata-variable throws val
   app_driver$stop()
 })
 
-testthat::test_that("e2e - tm_g_lineplot: Selecting y-variable changes plot and doesn't throw validation errors.", {
+testthat::test_that("e2e - tm_g_lineplot: Selecting y changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_lineplot()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("y-dataset_ADLB_singleextract-select", "BASE")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
 
-testthat::test_that("e2e - tm_g_lineplot: Deselecting y-variable throws validation error.", {
+testthat::test_that("e2e - tm_g_lineplot: Deselecting y throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_lineplot()
   app_driver$set_active_module_input("y-dataset_ADLB_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text(
       "y-dataset_ADLB_singleextract-select_input > div > span"
@@ -210,12 +205,12 @@ testthat::test_that("e2e - tm_g_lineplot: Deselecting y-variable throws validati
 testthat::test_that("e2e - tm_g_lineplot: Selecting conf_level changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_lineplot()
-  plot_before <- app_driver$get_active_module_pws_output("myplot")
+  plot_before <- app_driver$get_active_module_plot_output("myplot")
   app_driver$set_active_module_input("conf_level", "0.8")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("myplot")
+      app_driver$get_active_module_plot_output("myplot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -226,7 +221,7 @@ testthat::test_that("e2e - tm_g_lineplot: Deselecting conf_level validation erro
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_lineplot()
   app_driver$set_active_module_input("conf_level", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("conf_level_input > div > span"),
     "Please choose a confidence level"

--- a/tests/testthat/test-shinytest2-tm_g_pp_adverse_events.R
+++ b/tests/testthat/test-shinytest2-tm_g_pp_adverse_events.R
@@ -60,7 +60,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_pp_adverse_events()
     app_driver$expect_no_shiny_error()
     app_driver$expect_no_validation_error()
-    testthat::expect_match(app_driver$get_active_module_pws_output("chart"), "data:image/png;base64,")
+    testthat::expect_match(app_driver$get_active_module_plot_output("chart"), "data:image/png;base64,")
     testthat::expect_true(
       app_driver$is_visible(app_driver$active_module_element("table"))
     )
@@ -127,27 +127,19 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
-    plot_before <- app_driver$get_active_module_pws_output("chart")
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(
-        app_driver$active_module_element("table")
-      )
-    )[[1]]
+    plot_before <- app_driver$get_active_module_plot_output("chart")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("patient_id", "AB12345-CHN-15-id-262")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("chart")
+        app_driver$get_active_module_plot_output("chart")
       )
     )
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(
-          app_driver$get_html_rvest(
-            app_driver$active_module_element("table")
-          )
-        )[[1]]
+        app_driver$get_active_module_table_output("table-table-with-settings")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -176,28 +168,20 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
-    plot_before <- app_driver$get_active_module_pws_output("chart")
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(
-        app_driver$active_module_element("table")
-      )
-    )[[1]]
+    plot_before <- app_driver$get_active_module_plot_output("chart")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("aeterm-dataset_ADAE_singleextract-select", "AGEU")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("chart")
+        app_driver$get_active_module_plot_output("chart")
       )
     )
 
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(
-          app_driver$get_html_rvest(
-            app_driver$active_module_element("table")
-          )
-        )[[1]]
+        app_driver$get_active_module_table_output("table-table-with-settings")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -226,28 +210,20 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
-    plot_before <- app_driver$get_active_module_pws_output("chart")
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(
-        app_driver$active_module_element("table")
-      )
-    )[[1]]
+    plot_before <- app_driver$get_active_module_plot_output("chart")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("tox_grade-dataset_ADAE_singleextract-select", "COUNTRY")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("chart")
+        app_driver$get_active_module_plot_output("chart")
       )
     )
 
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(
-          app_driver$get_html_rvest(
-            app_driver$active_module_element("table")
-          )
-        )[[1]]
+        app_driver$get_active_module_table_output("table-table-with-settings")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -276,28 +252,20 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
-    plot_before <- app_driver$get_active_module_pws_output("chart")
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(
-        app_driver$active_module_element("table")
-      )
-    )[[1]]
+    plot_before <- app_driver$get_active_module_plot_output("chart")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("causality-dataset_ADAE_singleextract-select", "ACTARM")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("chart")
+        app_driver$get_active_module_plot_output("chart")
       )
     )
 
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(
-          app_driver$get_html_rvest(
-            app_driver$active_module_element("table")
-          )
-        )[[1]]
+        app_driver$get_active_module_table_output("table-table-with-settings")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -326,28 +294,20 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
-    plot_before <- app_driver$get_active_module_pws_output("chart")
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(
-        app_driver$active_module_element("table")
-      )
-    )[[1]]
+    plot_before <- app_driver$get_active_module_plot_output("chart")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("outcome-dataset_ADAE_singleextract-select", "SITEID")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("chart")
+        app_driver$get_active_module_plot_output("chart")
       )
     )
 
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(
-          app_driver$get_html_rvest(
-            app_driver$active_module_element("table")
-          )
-        )[[1]]
+        app_driver$get_active_module_table_output("table-table-with-settings")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -376,28 +336,20 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
-    plot_before <- app_driver$get_active_module_pws_output("chart")
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(
-        app_driver$active_module_element("table")
-      )
-    )[[1]]
+    plot_before <- app_driver$get_active_module_plot_output("chart")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("action-dataset_ADAE_singleextract-select", "SMQ01NAM")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("chart")
+        app_driver$get_active_module_plot_output("chart")
       )
     )
 
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(
-          app_driver$get_html_rvest(
-            app_driver$active_module_element("table")
-          )
-        )[[1]]
+        app_driver$get_active_module_table_output("table-table-with-settings")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -426,28 +378,20 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
-    plot_before <- app_driver$get_active_module_pws_output("chart")
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(
-        app_driver$active_module_element("table")
-      )
-    )[[1]]
+    plot_before <- app_driver$get_active_module_plot_output("chart")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("time-dataset_ADAE_singleextract-select", "AGE")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("chart")
+        app_driver$get_active_module_plot_output("chart")
       )
     )
 
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(
-          app_driver$get_html_rvest(
-            app_driver$active_module_element("table")
-          )
-        )[[1]]
+        app_driver$get_active_module_table_output("table-table-with-settings")
       )
     )
     app_driver$expect_no_shiny_error()

--- a/tests/testthat/test-shinytest2-tm_g_pp_adverse_events.R
+++ b/tests/testthat/test-shinytest2-tm_g_pp_adverse_events.R
@@ -128,7 +128,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
     plot_before <- app_driver$get_active_module_plot_output("chart")
-    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
+    table_before <- app_driver$get_active_module_table_output("table")
     app_driver$set_active_module_input("patient_id", "AB12345-CHN-15-id-262")
     testthat::expect_false(
       identical(
@@ -139,7 +139,7 @@ testthat::test_that(
     testthat::expect_false(
       identical(
         table_before,
-        app_driver$get_active_module_table_output("table-table-with-settings")
+        app_driver$get_active_module_table_output("table")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -169,7 +169,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
     plot_before <- app_driver$get_active_module_plot_output("chart")
-    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
+    table_before <- app_driver$get_active_module_table_output("table")
     app_driver$set_active_module_input("aeterm-dataset_ADAE_singleextract-select", "AGEU")
     testthat::expect_false(
       identical(
@@ -181,7 +181,7 @@ testthat::test_that(
     testthat::expect_false(
       identical(
         table_before,
-        app_driver$get_active_module_table_output("table-table-with-settings")
+        app_driver$get_active_module_table_output("table")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -211,7 +211,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
     plot_before <- app_driver$get_active_module_plot_output("chart")
-    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
+    table_before <- app_driver$get_active_module_table_output("table")
     app_driver$set_active_module_input("tox_grade-dataset_ADAE_singleextract-select", "COUNTRY")
     testthat::expect_false(
       identical(
@@ -223,7 +223,7 @@ testthat::test_that(
     testthat::expect_false(
       identical(
         table_before,
-        app_driver$get_active_module_table_output("table-table-with-settings")
+        app_driver$get_active_module_table_output("table")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -253,7 +253,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
     plot_before <- app_driver$get_active_module_plot_output("chart")
-    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
+    table_before <- app_driver$get_active_module_table_output("table")
     app_driver$set_active_module_input("causality-dataset_ADAE_singleextract-select", "ACTARM")
     testthat::expect_false(
       identical(
@@ -265,7 +265,7 @@ testthat::test_that(
     testthat::expect_false(
       identical(
         table_before,
-        app_driver$get_active_module_table_output("table-table-with-settings")
+        app_driver$get_active_module_table_output("table")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -295,7 +295,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
     plot_before <- app_driver$get_active_module_plot_output("chart")
-    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
+    table_before <- app_driver$get_active_module_table_output("table")
     app_driver$set_active_module_input("outcome-dataset_ADAE_singleextract-select", "SITEID")
     testthat::expect_false(
       identical(
@@ -307,7 +307,7 @@ testthat::test_that(
     testthat::expect_false(
       identical(
         table_before,
-        app_driver$get_active_module_table_output("table-table-with-settings")
+        app_driver$get_active_module_table_output("table")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -337,7 +337,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
     plot_before <- app_driver$get_active_module_plot_output("chart")
-    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
+    table_before <- app_driver$get_active_module_table_output("table")
     app_driver$set_active_module_input("action-dataset_ADAE_singleextract-select", "SMQ01NAM")
     testthat::expect_false(
       identical(
@@ -349,7 +349,7 @@ testthat::test_that(
     testthat::expect_false(
       identical(
         table_before,
-        app_driver$get_active_module_table_output("table-table-with-settings")
+        app_driver$get_active_module_table_output("table")
       )
     )
     app_driver$expect_no_shiny_error()
@@ -379,7 +379,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
     plot_before <- app_driver$get_active_module_plot_output("chart")
-    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
+    table_before <- app_driver$get_active_module_table_output("table")
     app_driver$set_active_module_input("time-dataset_ADAE_singleextract-select", "AGE")
     testthat::expect_false(
       identical(
@@ -391,7 +391,7 @@ testthat::test_that(
     testthat::expect_false(
       identical(
         table_before,
-        app_driver$get_active_module_table_output("table-table-with-settings")
+        app_driver$get_active_module_table_output("table")
       )
     )
     app_driver$expect_no_shiny_error()

--- a/tests/testthat/test-shinytest2-tm_g_pp_patient_timeline.R
+++ b/tests/testthat/test-shinytest2-tm_g_pp_patient_timeline.R
@@ -1,5 +1,5 @@
 app_driver_tm_g_pp_patient_timeline <- function() { # nolint object_length
-  data <- teal_data()
+  data <- teal.data::teal_data()
   data <- within(data, {
     library(dplyr)
     ADAE <- tmc_ex_adae
@@ -75,7 +75,13 @@ app_driver_tm_g_pp_patient_timeline <- function() { # nolint object_length
       dsrelday_end = teal.transform::choices_selected(
         choices = teal.transform::variable_choices(data[["ADCM"]], c("AENDY", "ASTDY")),
         selected = "AENDY"
-      )
+      ),
+      font_size = c(12L, 12L, 25L),
+      plot_height = c(700L, 200L, 2000L),
+      plot_width = NULL,
+      pre_output = NULL,
+      post_output = NULL,
+      ggplot2_args = teal.widgets::ggplot2_args()
     )
   )
 }
@@ -89,7 +95,7 @@ testthat::test_that(
     app_driver$expect_no_validation_error()
 
     testthat::expect_match(
-      app_driver$get_active_module_pws_output("patient_timeline_plot"),
+      app_driver$get_active_module_plot_output("patient_timeline_plot"),
       "data:image/png;base64,"
     )
 
@@ -99,7 +105,7 @@ testthat::test_that(
 
 testthat::test_that(
   "e2e - tm_g_pp_patient_timeline: Starts with specified label, patient_id, cmdecod, aeterm, aetime_start,
-  aetime_end, dstime_start, dstime_end, aerelday_start, aerelday_end, dsrelday_start, dsrelday_en",
+  aetime_end, dstime_start, dstime_end, aerelday_start, aerelday_end, dsrelday_start, dsrelday_en.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
@@ -163,7 +169,7 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_g_pp_patient_timeline: aerelday_start, aerelday_end, dsrelday_start, dsrelday_end
+  "e2e - tm_g_pp_patient_timeline: Encodings aerelday_start, aerelday_end, dsrelday_start, dsrelday_end
   are shown only when relday_x_axis is checked.",
   {
     skip_if_too_deep(5)
@@ -194,7 +200,7 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_g_pp_patient_timeline: aetime_start, aetime_end, dstime_start, dstime_end
+  "e2e - tm_g_pp_patient_timeline: Encodings aetime_start, aetime_end, dstime_start, dstime_end
   are shown only when relday_x_axis is unchecked.",
   {
     skip_if_too_deep(5)
@@ -229,12 +235,12 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("patient_id", "AB12345-USA-2-id-3")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("patient_timeline_plot")
+        app_driver$get_active_module_plot_output("patient_timeline_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -246,7 +252,7 @@ testthat::test_that("e2e - tm_g_pp_patient_timeline: Deselecting patient_id colu
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_pp_patient_timeline()
   app_driver$set_active_module_input("patient_id", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("patient_timeline_plot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("patient_timeline_plot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("patient_id_input > div > span"),
     "Please select a patient"
@@ -260,12 +266,12 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("cmdecod-dataset_ADCM_singleextract-select", "CMCAT")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("patient_timeline_plot")
+        app_driver$get_active_module_plot_output("patient_timeline_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -278,9 +284,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("cmdecod-dataset_ADCM_singleextract-select", NULL)
-    testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("patient_timeline_plot")))
+    testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("patient_timeline_plot")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -291,12 +297,12 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("aeterm-dataset_ADAE_singleextract-select", "AESOC")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("patient_timeline_plot")
+        app_driver$get_active_module_plot_output("patient_timeline_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -309,9 +315,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("aeterm-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("patient_timeline_plot")))
+    testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("patient_timeline_plot")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -323,12 +329,12 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("relday_x_axis", FALSE)
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("aetime_start-dataset_ADAE_singleextract-select", "TRTSDTM")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("patient_timeline_plot")
+        app_driver$get_active_module_plot_output("patient_timeline_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -343,7 +349,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("relday_x_axis", FALSE)
     app_driver$set_active_module_input("aetime_start-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+    testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
     testthat::expect_identical(
       app_driver$active_module_element_text("aetime_start-dataset_ADAE_singleextract-select_input > div > span"),
       "Please add AE start date."
@@ -359,12 +365,12 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("relday_x_axis", FALSE)
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("aetime_end-dataset_ADAE_singleextract-select", "EOSDT")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("patient_timeline_plot")
+        app_driver$get_active_module_plot_output("patient_timeline_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -379,7 +385,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("relday_x_axis", FALSE)
     app_driver$set_active_module_input("aetime_end-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+    testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
     testthat::expect_identical(
       app_driver$active_module_element_text("aetime_end-dataset_ADAE_singleextract-select_input > div > span"),
       "Please add AE end date."
@@ -394,12 +400,12 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("aerelday_start-dataset_ADAE_singleextract-select", "AENDY")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("patient_timeline_plot")
+        app_driver$get_active_module_plot_output("patient_timeline_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -413,7 +419,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("aerelday_start-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+    testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
     testthat::expect_identical(
       app_driver$active_module_element_text("aerelday_start-dataset_ADAE_singleextract-select_input > div > span"),
       "Please add AE start date."
@@ -428,12 +434,12 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("aerelday_end-dataset_ADAE_singleextract-select", "ASTDY")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("patient_timeline_plot")
+        app_driver$get_active_module_plot_output("patient_timeline_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -447,7 +453,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("aerelday_end-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+    testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
     testthat::expect_identical(
       app_driver$active_module_element_text("aerelday_end-dataset_ADAE_singleextract-select_input > div > span"),
       "Please add AE end date."
@@ -463,12 +469,12 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("relday_x_axis", FALSE)
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("dstime_start-dataset_ADCM_singleextract-select", "TRTEDTM")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("patient_timeline_plot")
+        app_driver$get_active_module_plot_output("patient_timeline_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -483,7 +489,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("relday_x_axis", FALSE)
     app_driver$set_active_module_input("dstime_start-dataset_ADCM_singleextract-select", NULL)
-    testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+    testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
     testthat::expect_identical(
       app_driver$active_module_element_text("dstime_start-dataset_ADCM_singleextract-select_input > div > span"),
       "Please add Medication start date."
@@ -499,12 +505,12 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("relday_x_axis", FALSE)
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("dstime_end-dataset_ADCM_singleextract-select", "TRTEDTM")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("patient_timeline_plot")
+        app_driver$get_active_module_plot_output("patient_timeline_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -519,7 +525,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("relday_x_axis", FALSE)
     app_driver$set_active_module_input("dstime_end-dataset_ADCM_singleextract-select", NULL)
-    testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+    testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
     testthat::expect_identical(
       app_driver$active_module_element_text("dstime_end-dataset_ADCM_singleextract-select_input > div > span"),
       "Please add Medication end date."
@@ -534,12 +540,12 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("dsrelday_start-dataset_ADCM_singleextract-select", "AENDY")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("patient_timeline_plot")
+        app_driver$get_active_module_plot_output("patient_timeline_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -553,7 +559,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("dsrelday_start-dataset_ADCM_singleextract-select", NULL)
-    testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+    testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
     testthat::expect_identical(
       app_driver$active_module_element_text("dsrelday_start-dataset_ADCM_singleextract-select_input > div > span"),
       "Please add Medication start date."
@@ -568,12 +574,12 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
-    plot_before <- app_driver$get_active_module_pws_output("patient_timeline_plot")
+    plot_before <- app_driver$get_active_module_plot_output("patient_timeline_plot")
     app_driver$set_active_module_input("dsrelday_end-dataset_ADCM_singleextract-select", "ASTDY")
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("patient_timeline_plot")
+        app_driver$get_active_module_plot_output("patient_timeline_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -587,7 +593,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_patient_timeline()
     app_driver$set_active_module_input("dsrelday_end-dataset_ADCM_singleextract-select", NULL)
-    testthat::expect_identical(app_driver$get_active_module_pws_output("myplot"), character(0))
+    testthat::expect_identical(app_driver$get_active_module_plot_output("myplot"), character(0))
     testthat::expect_identical(
       app_driver$active_module_element_text("dsrelday_end-dataset_ADCM_singleextract-select_input > div > span"),
       "Please add Medication end date."

--- a/tests/testthat/test-shinytest2-tm_g_pp_patient_timeline.R
+++ b/tests/testthat/test-shinytest2-tm_g_pp_patient_timeline.R
@@ -77,7 +77,6 @@ app_driver_tm_g_pp_patient_timeline <- function() { # nolint object_length
         selected = "AENDY"
       ),
       font_size = c(12L, 12L, 25L),
-      plot_height = c(700L, 200L, 2000L),
       plot_width = NULL,
       pre_output = NULL,
       post_output = NULL,

--- a/tests/testthat/test-shinytest2-tm_g_pp_therapy.R
+++ b/tests/testthat/test-shinytest2-tm_g_pp_therapy.R
@@ -154,7 +154,7 @@ test_different_selection <- function(input_name, input_id, new_value) { # nolint
       skip_if_too_deep(5)
       app_driver <- app_driver_tm_g_pp_therapy()
       plot_before <- list(
-        app_driver$get_active_module_pws_output("therapy_plot"),
+        app_driver$get_active_module_plot_output("therapy_plot"),
         app_driver$active_module_element_text("therapy_table")
       )
       app_driver$set_active_module_input(input_id, new_value)
@@ -162,7 +162,7 @@ test_different_selection <- function(input_name, input_id, new_value) { # nolint
         identical(
           plot_before,
           list(
-            app_driver$get_active_module_pws_output("therapy_plot"),
+            app_driver$get_active_module_plot_output("therapy_plot"),
             app_driver$active_module_element_text("therapy_table")
           )
         )
@@ -189,9 +189,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_therapy()
-    plot_before <- app_driver$get_active_module_pws_output("therapy_plot")
+    plot_before <- app_driver$get_active_module_plot_output("therapy_plot")
     app_driver$set_active_module_input("font_size", 15)
-    testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("therapy_plot")))
+    testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("therapy_plot")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_g_pp_vitals.R
+++ b/tests/testthat/test-shinytest2-tm_g_pp_vitals.R
@@ -28,7 +28,11 @@ app_driver_tm_g_pp_vitals <- function() {
       aval_var = teal.transform::choices_selected(
         choices = teal.transform::variable_choices(data[["ADVS"]], c("AVAL", "BASE2")),
         selected = "AVAL"
-      )
+      ),
+      plot_width = NULL,
+      pre_output = NULL,
+      post_output = NULL,
+      ggplot2_args = teal.widgets::ggplot2_args()
     )
   )
 }
@@ -91,12 +95,12 @@ testthat::test_that(
 testthat::test_that("e2e - tm_g_pp_vitals: Selecting patient_id changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_pp_vitals()
-  plot_before <- app_driver$get_active_module_pws_output("vitals_plot")
+  plot_before <- app_driver$get_active_module_plot_output("vitals_plot")
   app_driver$set_active_module_input("patient_id", "AB12345-CHN-15-id-262")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("vitals_plot")
+      app_driver$get_active_module_plot_output("vitals_plot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -107,7 +111,7 @@ testthat::test_that("e2e - tm_g_pp_vitals: Deselecting patient_id column throws 
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_pp_vitals()
   app_driver$set_active_module_input("patient_id", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("vitals_plot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("vitals_plot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("patient_id_input > div > span"),
     "Please select a patient."
@@ -122,7 +126,7 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_vitals()
-    plot_before <- app_driver$get_active_module_pws_output("vitals_plot")
+    plot_before <- app_driver$get_active_module_plot_output("vitals_plot")
 
     # Changing the PARAMCD variable
     app_driver$set_active_module_input("paramcd-dataset_ADVS_singleextract-select", "PARAM")
@@ -147,7 +151,7 @@ testthat::test_that(
     testthat::expect_false(
       identical(
         plot_before,
-        app_driver$get_active_module_pws_output("vitals_plot")
+        app_driver$get_active_module_plot_output("vitals_plot")
       )
     )
     app_driver$expect_no_validation_error()
@@ -159,7 +163,7 @@ testthat::test_that("e2e - tm_g_pp_vitals: Deselecting paramcd throws validation
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_pp_vitals()
   app_driver$set_active_module_input("paramcd-dataset_ADVS_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("vitals_plot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("vitals_plot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("paramcd-dataset_ADVS_singleextract-select_input > div > span"),
     "Please select PARAMCD variable."
@@ -171,12 +175,12 @@ testthat::test_that("e2e - tm_g_pp_vitals: Deselecting paramcd throws validation
 testthat::test_that("e2e - tm_g_pp_vitals: Selecting xaxis changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_pp_vitals()
-  plot_before <- app_driver$get_active_module_pws_output("vitals_plot")
+  plot_before <- app_driver$get_active_module_plot_output("vitals_plot")
   app_driver$set_active_module_input("xaxis-dataset_ADVS_singleextract-select", "BMRKR1")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("vitals_plot")
+      app_driver$get_active_module_plot_output("vitals_plot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -187,7 +191,7 @@ testthat::test_that("e2e - tm_g_pp_vitals: Deselecting xaxis column throws valid
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_pp_vitals()
   app_driver$set_active_module_input("xaxis-dataset_ADVS_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("vitals_plot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("vitals_plot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("xaxis-dataset_ADVS_singleextract-select_input > div > span"),
     "Please select Vitals x-axis variable."
@@ -199,12 +203,12 @@ testthat::test_that("e2e - tm_g_pp_vitals: Deselecting xaxis column throws valid
 testthat::test_that("e2e - tm_g_pp_vitals: Selecting aval_var changes plot and doesn't throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_pp_vitals()
-  plot_before <- app_driver$get_active_module_pws_output("vitals_plot")
+  plot_before <- app_driver$get_active_module_plot_output("vitals_plot")
   app_driver$set_active_module_input("aval_var-dataset_ADVS_singleextract-select", "BASE2")
   testthat::expect_false(
     identical(
       plot_before,
-      app_driver$get_active_module_pws_output("vitals_plot")
+      app_driver$get_active_module_plot_output("vitals_plot")
     )
   )
   app_driver$expect_no_validation_error()
@@ -215,7 +219,7 @@ testthat::test_that("e2e - tm_g_pp_vitals: Deselecting aval_var column throws va
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_pp_vitals()
   app_driver$set_active_module_input("aval_var-dataset_ADVS_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_pws_output("vitals_plot"), character(0))
+  testthat::expect_identical(app_driver$get_active_module_plot_output("vitals_plot"), character(0))
   testthat::expect_identical(
     app_driver$active_module_element_text("aval_var-dataset_ADVS_singleextract-select_input > div > span"),
     "Please select AVAL variable."
@@ -227,9 +231,9 @@ testthat::test_that("e2e - tm_g_pp_vitals: Deselecting aval_var column throws va
 testthat::test_that("e2e - tm_g_pp_vitals: Changing font_size changes plot and doesn't throw validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_g_pp_vitals()
-  plot_before <- app_driver$get_active_module_pws_output("vitals_plot")
+  plot_before <- app_driver$get_active_module_plot_output("vitals_plot")
   app_driver$set_active_module_input("font_size", 20)
-  testthat::expect_false(identical(plot_before, app_driver$get_active_module_pws_output("vitals_plot")))
+  testthat::expect_false(identical(plot_before, app_driver$get_active_module_plot_output("vitals_plot")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })

--- a/tests/testthat/test-shinytest2-tm_t_abnormality.R
+++ b/tests/testthat/test-shinytest2-tm_t_abnormality.R
@@ -21,6 +21,7 @@ app_driver_tm_t_abnormality <- function() {
     modules = tm_t_abnormality(
       label = "Abnormality Table",
       dataname = "ADLB",
+      parentname = "ADSL",
       arm_var = teal.transform::choices_selected(
         choices = teal.transform::variable_choices(data[["ADSL"]], subset = c("ARM", "ARMCD")),
         selected = "ARM"
@@ -41,7 +42,23 @@ app_driver_tm_t_abnormality <- function() {
         fixed = TRUE
       ),
       abnormal = list(low = "LOW", high = "HIGH"),
-      exclude_base_abn = FALSE
+      id_var = teal.transform::choices_selected(
+        teal.transform::variable_choices(data[["ADLB"]], subset = "USUBJID"),
+        selected = "USUBJID", fixed = TRUE
+      ),
+      exclude_base_abn = FALSE,
+      treatment_flag_var = teal.transform::choices_selected(
+        teal.transform::variable_choices(data[["ADLB"]], subset = "ONTRTFL"),
+        selected = "ONTRTFL", fixed = TRUE
+      ),
+      treatment_flag = teal.transform::choices_selected("Y"),
+      total_label = default_total_label(),
+      exclude_base_abn = FALSE,
+      drop_arm_levels = TRUE,
+      pre_output = NULL,
+      post_output = NULL,
+      na_level = default_na_str(),
+      basic_table_args = teal.widgets::basic_table_args()
     )
   )
 }
@@ -97,9 +114,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_abnormality()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -109,7 +126,7 @@ testthat::test_that("e2e - arm_var: Deselection of arm_var throws validation err
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_abnormality()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -123,9 +140,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_abnormality()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("by_vars-dataset_ADLB_singleextract-select", "AVISIT")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -135,7 +152,7 @@ testthat::test_that("e2e - tm_t_abnormality: Deselection of by_vars throws valid
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_abnormality()
   app_driver$set_active_module_input("by_vars-dataset_ADLB_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("by_vars-dataset_ADLB_singleextract-select_input .shiny-validation-message"),
@@ -149,9 +166,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_abnormality()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("add_total", TRUE)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -162,9 +179,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_abnormality()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("exclude_base_abn", TRUE)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -175,9 +192,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_abnormality()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("drop_arm_levels", FALSE)
-    testthat::expect_true(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_true(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_abnormality.R
+++ b/tests/testthat/test-shinytest2-tm_t_abnormality.R
@@ -53,7 +53,6 @@ app_driver_tm_t_abnormality <- function() {
       ),
       treatment_flag = teal.transform::choices_selected("Y"),
       total_label = default_total_label(),
-      exclude_base_abn = FALSE,
       drop_arm_levels = TRUE,
       pre_output = NULL,
       post_output = NULL,

--- a/tests/testthat/test-shinytest2-tm_t_abnormality.R
+++ b/tests/testthat/test-shinytest2-tm_t_abnormality.R
@@ -213,7 +213,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_abnormality()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("drop_arm_levels", FALSE)
-    testthat::expect_false(
+    testthat::expect_true(
       identical(
         table_before,
         app_driver$get_active_module_table_output("table-table-with-settings")

--- a/tests/testthat/test-shinytest2-tm_t_abnormality.R
+++ b/tests/testthat/test-shinytest2-tm_t_abnormality.R
@@ -116,7 +116,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_abnormality()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -142,7 +147,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_abnormality()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("by_vars-dataset_ADLB_singleextract-select", "AVISIT")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -168,7 +178,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_abnormality()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("add_total", TRUE)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -181,7 +196,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_abnormality()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("exclude_base_abn", TRUE)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -194,7 +214,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_abnormality()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("drop_arm_levels", FALSE)
-    testthat::expect_true(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_abnormality_by_worst_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_abnormality_by_worst_grade.R
@@ -124,7 +124,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_abnormality_by_worst_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -137,7 +142,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_abnormality_by_worst_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-filter1-vals", c("ALT", "CRP"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -178,7 +188,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_abnormality_by_worst_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("add_total", TRUE)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_abnormality_by_worst_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_abnormality_by_worst_grade.R
@@ -17,15 +17,38 @@ app_driver_tm_t_abnormality_by_worst_grade <- function() { # nolint: object_leng
     modules = tm_t_abnormality_by_worst_grade(
       label = "Laboratory Test Results with Highest Grade Post-Baseline",
       dataname = "ADLB",
+      parentname = "ADSL",
       arm_var = teal.transform::choices_selected(
         choices = teal.transform::variable_choices(data[["ADSL"]], subset = c("ARM", "ARMCD")),
         selected = "ARM"
+      ),
+      id_var = teal.transform::choices_selected(
+        teal.transform::variable_choices(data[["ADLB"]], subset = "USUBJID"),
+        selected = "USUBJID", fixed = TRUE
       ),
       paramcd = teal.transform::choices_selected(
         choices = teal.transform::value_choices(data[["ADLB"]], "PARAMCD", "PARAM"),
         selected = c("ALT", "CRP", "IGA")
       ),
-      add_total = FALSE
+      add_total = FALSE,
+      atoxgr_var = teal.transform::choices_selected(
+        teal.transform::variable_choices(data[["ADLB"]], subset = "ATOXGR"),
+        selected = "ATOXGR", fixed = TRUE
+      ),
+      worst_high_flag_var = teal.transform::choices_selected(
+        teal.transform::variable_choices(data[["ADLB"]], subset = "WGRHIFL"),
+        selected = "WGRHIFL", fixed = TRUE
+      ),
+      worst_low_flag_var = teal.transform::choices_selected(
+        teal.transform::variable_choices(data[["ADLB"]], subset = "WGRLOFL"),
+        selected = "WGRLOFL", fixed = TRUE
+      ),
+      worst_flag_indicator = teal.transform::choices_selected("Y"),
+      total_label = default_total_label(),
+      drop_arm_levels = TRUE,
+      pre_output = NULL,
+      post_output = NULL,
+      basic_table_args = teal.widgets::basic_table_args()
     ),
     filter = teal::teal_slices(
       teal_slice("ADSL", "SAFFL", selected = "Y"),
@@ -51,7 +74,7 @@ testthat::test_that(
 
 testthat::test_that(
   "e2e - tm_t_abnormality_by_worst_grade: Starts with specified label, arm_var, paramcd, id_var, atoxgr_var,
-  worst_high_flag_var, worst_low_flag_var, worst_flag_indicator, add_total, drop_arm_levels",
+  worst_high_flag_var, worst_low_flag_var, worst_flag_indicator, add_total, drop_arm_levels.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_abnormality_by_worst_grade()
@@ -99,9 +122,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_abnormality_by_worst_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -112,9 +135,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_abnormality_by_worst_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-filter1-vals", c("ALT", "CRP"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -124,7 +147,7 @@ testthat::test_that("e2e - tm_t_abnormality_by_worst_grade: Deselection of arm_v
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_abnormality_by_worst_grade()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -137,7 +160,7 @@ testthat::test_that("e2e - tm_t_abnormality_by_worst_grade: Deselection of param
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_abnormality_by_worst_grade()
   app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -153,9 +176,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_abnormality_by_worst_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("add_total", TRUE)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -167,9 +190,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_abnormality_by_worst_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("drop_arm_levels", FALSE)
-    testthat::expect_identical(table_before, app_driver$get_active_module_tws_output("table"))
+    testthat::expect_identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings"))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_ancova.R
+++ b/tests/testthat/test-shinytest2-tm_t_ancova.R
@@ -129,26 +129,26 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_ancova: Selecting avisit-level changes the table and does not throw validation errors.",
+  "e2e - tm_t_ancova: Selecting avisit changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_ancova()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input(
       "avisit-dataset_ADQS_singleextract-filter1-vals",
       c("WEEK 1 DAY 8", "WEEK 2 DAY 15")
     )
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_ancova: Deselection of avisit-level throws validation error.", {
+testthat::test_that("e2e - tm_t_ancova: Deselection of avisit throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_ancova()
   app_driver$set_active_module_input("avisit-dataset_ADQS_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -160,23 +160,23 @@ testthat::test_that("e2e - tm_t_ancova: Deselection of avisit-level throws valid
 })
 
 testthat::test_that(
-  "e2e - tm_t_ancova: Selecting paramcd-level changes the table and does not throw validation errors.",
+  "e2e - tm_t_ancova: Selecting paramcd changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_ancova()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADQS_singleextract-filter1-vals", c("BFIALL", "FATIGI"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_ancova: Deselection of paramcd-level throws validation error.", {
+testthat::test_that("e2e - tm_t_ancova: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_ancova()
   app_driver$set_active_module_input("paramcd-dataset_ADQS_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -188,23 +188,23 @@ testthat::test_that("e2e - tm_t_ancova: Deselection of paramcd-level throws vali
 })
 
 testthat::test_that(
-  "e2e - tm_t_ancova: Selecting aval_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_ancova: Selecting aval_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_ancova()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("aval_var-dataset_ADQS_singleextract-select", "AVAL")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_ancova: Deselection of aval_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_ancova: Deselection of aval_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_ancova()
   app_driver$set_active_module_input("aval_var-dataset_ADQS_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("aval_var-dataset_ADQS_singleextract-select_input .shiny-validation-message"),
@@ -214,23 +214,23 @@ testthat::test_that("e2e - tm_t_ancova: Deselection of aval_var-variable throws 
 })
 
 testthat::test_that(
-  "e2e - tm_t_ancova: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_ancova: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_ancova()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_ancova: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_ancova: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_ancova()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -240,26 +240,26 @@ testthat::test_that("e2e - tm_t_ancova: Deselection of arm_var-variable throws v
 })
 
 testthat::test_that(
-  "e2e - tm_t_ancova: Selecting cov_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_ancova: Selecting cov_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_ancova()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("cov_var-dataset_ADQS_singleextract-select", "BASE")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_ancova: Deselection of cov_var-variable changes table and doesn't throw validation error.",
+  "e2e - tm_t_ancova: Deselection of cov_var changes table and doesn't throw validation error.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_ancova()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("cov_var-dataset_ADQS_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_ancova.R
+++ b/tests/testthat/test-shinytest2-tm_t_ancova.R
@@ -138,7 +138,12 @@ testthat::test_that(
       "avisit-dataset_ADQS_singleextract-filter1-vals",
       c("WEEK 1 DAY 8", "WEEK 2 DAY 15")
     )
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -166,7 +171,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_ancova()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADQS_singleextract-filter1-vals", c("BFIALL", "FATIGI"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -194,7 +204,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_ancova()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("aval_var-dataset_ADQS_singleextract-select", "AVAL")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -220,7 +235,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_ancova()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -246,7 +266,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_ancova()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("cov_var-dataset_ADQS_singleextract-select", "BASE")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -259,7 +284,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_ancova()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("cov_var-dataset_ADQS_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_binary_outcome.R
+++ b/tests/testthat/test-shinytest2-tm_t_binary_outcome.R
@@ -170,23 +170,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_binary_outcome: Selecting paramcd-level changes the table and does not throw validation errors.",
+  "e2e - tm_t_binary_outcome: Selecting paramcd changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_binary_outcome()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADRS_singleextract-filter1-vals", "INVET")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_binary_outcome: Deselection of paramcd-level throws validation error.", {
+testthat::test_that("e2e - tm_t_binary_outcome: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_binary_outcome()
   app_driver$set_active_module_input("paramcd-dataset_ADRS_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -202,9 +202,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_binary_outcome()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("responders", c("Stable Disease (SD)", "Progressive Disease (PD)"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -214,7 +214,7 @@ testthat::test_that("e2e - tm_t_binary_outcome: Deselection of responders throws
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_binary_outcome()
   app_driver$set_active_module_input("responders", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$get_text("#teal-main_ui-root-responders .shiny-validation-message"),
@@ -224,23 +224,23 @@ testthat::test_that("e2e - tm_t_binary_outcome: Deselection of responders throws
 })
 
 testthat::test_that(
-  "e2e - tm_t_binary_outcome: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_binary_outcome: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_binary_outcome()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_binary_outcome: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_binary_outcome: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_binary_outcome()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -250,27 +250,27 @@ testthat::test_that("e2e - tm_t_binary_outcome: Deselection of arm_var-variable 
 })
 
 testthat::test_that(
-  "e2e - tm_t_binary_outcome: Selecting strata_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_binary_outcome: Selecting strata_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_binary_outcome()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", "SEX")
 
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_binary_outcome: Deselection of strata_var-variable changes the table and does not throw validation errors.", # nolint line_length_linter
+  "e2e - tm_t_binary_outcome: Deselection of strata_var changes the table and does not throw validation errors.", # nolint line_length_linter
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_binary_outcome()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_binary_outcome.R
+++ b/tests/testthat/test-shinytest2-tm_t_binary_outcome.R
@@ -176,7 +176,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_binary_outcome()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADRS_singleextract-filter1-vals", "INVET")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -204,7 +209,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_binary_outcome()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("responders", c("Stable Disease (SD)", "Progressive Disease (PD)"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -230,7 +240,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_binary_outcome()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -257,7 +272,12 @@ testthat::test_that(
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", "SEX")
 
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -270,7 +290,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_binary_outcome()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_coxreg.R
+++ b/tests/testthat/test-shinytest2-tm_t_coxreg.R
@@ -130,7 +130,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_coxreg()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADTTE_singleextract-filter1-vals", "CRSD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -158,7 +163,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_coxreg()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -184,7 +194,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_coxreg()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("cov_var-dataset_ADSL_singleextract-select", c("BMRKR1", "BMRKR2"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -197,7 +212,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_coxreg()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("cov_var-dataset_ADSL_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -210,7 +230,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_coxreg()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", c("STRATA2", "COUNTRY"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -223,7 +248,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_coxreg()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_coxreg.R
+++ b/tests/testthat/test-shinytest2-tm_t_coxreg.R
@@ -124,23 +124,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_coxreg: Selecting paramcd-level changes the table and does not throw validation errors.",
+  "e2e - tm_t_coxreg: Selecting paramcd changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_coxreg()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADTTE_singleextract-filter1-vals", "CRSD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_coxreg: Deselection of paramcd-level throws validation error.", {
+testthat::test_that("e2e - tm_t_coxreg: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_coxreg()
   app_driver$set_active_module_input("paramcd-dataset_ADTTE_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -152,23 +152,23 @@ testthat::test_that("e2e - tm_t_coxreg: Deselection of paramcd-level throws vali
 })
 
 testthat::test_that(
-  "e2e - tm_t_coxreg: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_coxreg: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_coxreg()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_coxreg: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_coxreg: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_coxreg()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -178,52 +178,52 @@ testthat::test_that("e2e - tm_t_coxreg: Deselection of arm_var-variable throws v
 })
 
 testthat::test_that(
-  "e2e - tm_t_coxreg: Selecting cov_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_coxreg: Selecting cov_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_coxreg()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("cov_var-dataset_ADSL_singleextract-select", c("BMRKR1", "BMRKR2"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_coxreg: Deselection of cov_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_coxreg: Deselection of cov_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_coxreg()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("cov_var-dataset_ADSL_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_coxreg: Selecting strata_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_coxreg: Selecting strata_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_coxreg()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", c("STRATA2", "COUNTRY"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_coxreg: Deselection of strata_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_coxreg: Deselection of strata_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_coxreg()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_events.R
+++ b/tests/testthat/test-shinytest2-tm_t_events.R
@@ -93,23 +93,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_events: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_events: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_events: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_events()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -119,52 +119,52 @@ testthat::test_that("e2e - tm_t_events: Deselection of arm_var-variable throws v
 })
 
 testthat::test_that(
-  "e2e - tm_t_events: Selecting hlt-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events: Selecting hlt changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADAE_singleextract-select", "AESOC")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_events: Deselection of hlt-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events: Deselection of hlt changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_events: Selecting llt-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events: Selecting llt changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("llt-dataset_ADAE_singleextract-select", "AETERM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_events: Deselection of llt-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events: Deselection of llt changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("llt-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_events.R
+++ b/tests/testthat/test-shinytest2-tm_t_events.R
@@ -99,7 +99,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -125,7 +130,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADAE_singleextract-select", "AESOC")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -138,7 +148,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -151,7 +166,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("llt-dataset_ADAE_singleextract-select", "AETERM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -164,7 +184,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("llt-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_events_by_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_events_by_grade.R
@@ -107,23 +107,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_events_by_grade: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events_by_grade: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_by_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_events_by_grade: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_events_by_grade: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_events_by_grade()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -133,75 +133,75 @@ testthat::test_that("e2e - tm_t_events_by_grade: Deselection of arm_var-variable
 })
 
 testthat::test_that(
-  "e2e - tm_t_events_by_grade: Selecting hlt-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events_by_grade: Selecting hlt changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_by_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADAE_singleextract-select", "AESOC")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_events_by_grade: Deselection of hlt-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events_by_grade: Deselection of hlt changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_by_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_events_by_grade: Selecting llt-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events_by_grade: Selecting llt changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_by_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("llt-dataset_ADAE_singleextract-select", "AETERM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_events_by_grade: Deselection of llt-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events_by_grade: Deselection of llt changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_by_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("llt-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_events_by_grade: Selecting grade-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events_by_grade: Selecting grade changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_by_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("grade-dataset_ADAE_singleextract-select", "AESEV")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_events_by_grade: Deselection of grade-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_events_by_grade: Deselection of grade throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_events_by_grade()
   app_driver$set_active_module_input("grade-dataset_ADAE_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("grade-dataset_ADAE_singleextract-select_input .shiny-validation-message"),

--- a/tests/testthat/test-shinytest2-tm_t_events_by_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_events_by_grade.R
@@ -113,7 +113,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_by_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -139,7 +144,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_by_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADAE_singleextract-select", "AESOC")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -152,7 +162,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_by_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -165,7 +180,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_by_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("llt-dataset_ADAE_singleextract-select", "AETERM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -178,7 +198,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_by_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("llt-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -191,7 +216,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_by_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("grade-dataset_ADAE_singleextract-select", "AESEV")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_events_patyear.R
+++ b/tests/testthat/test-shinytest2-tm_t_events_patyear.R
@@ -113,9 +113,11 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_patyear()
     table_before <- app_driver$get_active_module_table_output("patyear_table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADAETTE_singleextract-filter1-vals", "AETTE2")
-    testthat::expect_identical(
-      app_driver$get_active_module_table_output("patyear_table-table-with-settings"),
-      data.frame()
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("patyear_table-table-with-settings")
+      )
     )
     app_driver$expect_no_validation_error()
     app_driver$stop()
@@ -147,9 +149,11 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_patyear()
     table_before <- app_driver$get_active_module_table_output("patyear_table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARM")
-    testthat::expect_identical(
-      app_driver$get_active_module_table_output("patyear_table-table-with-settings"),
-      data.frame()
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("patyear_table-table-with-settings")
+      )
     )
     app_driver$expect_no_validation_error()
     app_driver$stop()

--- a/tests/testthat/test-shinytest2-tm_t_events_patyear.R
+++ b/tests/testthat/test-shinytest2-tm_t_events_patyear.R
@@ -113,7 +113,10 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_patyear()
     table_before <- app_driver$get_active_module_table_output("patyear_table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADAETTE_singleextract-filter1-vals", "AETTE2")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("patyear_table-table-with-settings")))
+    testthat::expect_identical(
+      app_driver$get_active_module_table_output("patyear_table-table-with-settings"),
+      data.frame()
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -123,7 +126,10 @@ testthat::test_that("e2e - tm_t_events_patyear: Deselection of paramcd throws va
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_events_patyear()
   app_driver$set_active_module_input("paramcd-dataset_ADAETTE_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_table_output("patyear_table-table-with-settings"), data.frame())
+  testthat::expect_identical(
+    app_driver$get_active_module_table_output("patyear_table-table-with-settings"),
+    data.frame()
+  )
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -141,7 +147,10 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_patyear()
     table_before <- app_driver$get_active_module_table_output("patyear_table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("patyear_table-table-with-settings")))
+    testthat::expect_identical(
+      app_driver$get_active_module_table_output("patyear_table-table-with-settings"),
+      data.frame()
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -151,7 +160,10 @@ testthat::test_that("e2e - tm_t_events_patyear: Deselection of arm_var throws va
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_events_patyear()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_table_output("patyear_table-table-with-settings"), data.frame())
+  testthat::expect_identical(
+    app_driver$get_active_module_table_output("patyear_table-table-with-settings"),
+    data.frame()
+  )
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),

--- a/tests/testthat/test-shinytest2-tm_t_events_patyear.R
+++ b/tests/testthat/test-shinytest2-tm_t_events_patyear.R
@@ -107,23 +107,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_events_patyear: Selecting paramcd-level changes the table and does not throw validation errors.",
+  "e2e - tm_t_events_patyear: Selecting paramcd changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_patyear()
-    table_before <- app_driver$get_active_module_tws_output("patyear_table")
+    table_before <- app_driver$get_active_module_table_output("patyear_table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADAETTE_singleextract-filter1-vals", "AETTE2")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("patyear_table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("patyear_table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_events_patyear: Deselection of paramcd-level throws validation error.", {
+testthat::test_that("e2e - tm_t_events_patyear: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_events_patyear()
   app_driver$set_active_module_input("paramcd-dataset_ADAETTE_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("patyear_table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("patyear_table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -135,23 +135,23 @@ testthat::test_that("e2e - tm_t_events_patyear: Deselection of paramcd-level thr
 })
 
 testthat::test_that(
-  "e2e - tm_t_events_patyear: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events_patyear: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_patyear()
-    table_before <- app_driver$get_active_module_tws_output("patyear_table")
+    table_before <- app_driver$get_active_module_table_output("patyear_table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("patyear_table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("patyear_table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_events_patyear: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_events_patyear: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_events_patyear()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("patyear_table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("patyear_table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),

--- a/tests/testthat/test-shinytest2-tm_t_events_summary.R
+++ b/tests/testthat/test-shinytest2-tm_t_events_summary.R
@@ -107,7 +107,7 @@ testthat::test_that("e2e - tm_t_events_summary: Module initializes in teal witho
 
 testthat::test_that(
   "e2e - tm_t_events_summary: Starts with specified label, arm_var, flag_var_anl, flag_var_aesi,
-  add_total, count_subj, count_pt, count_events",
+  add_total, count_subj, count_pt, count_events.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_summary()
@@ -136,23 +136,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_events_summary: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events_summary: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_summary()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_events_summary: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_events_summary: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_events_summary()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -162,27 +162,27 @@ testthat::test_that("e2e - tm_t_events_summary: Deselection of arm_var-variable 
 })
 
 testthat::test_that(
-  "e2e - tm_t_events_summary: Selecting flag_var_anl-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events_summary: Selecting flag_var_anl changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_summary()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("flag_var_anl-dataset_ADAE_singleextract-select", c("TMPFL_REL", "TMPFL_GR5"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_events_summary: Deselection of flag_var_anl-variable changes the table
+  "e2e - tm_t_events_summary: Deselection of flag_var_anl changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_summary()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("flag_var_anl-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -190,27 +190,27 @@ testthat::test_that(
 
 
 testthat::test_that(
-  "e2e - tm_t_events_summary: Selecting flag_var_aesi-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_events_summary: Selecting flag_var_aesi changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_summary()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("flag_var_aesi-dataset_ADAE_singleextract-select", c("TMP_SMQ02", "TMP_CQ01"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_events_summary: Deselection of flag_var_aesi-variable changes the table
+  "e2e - tm_t_events_summary: Deselection of flag_var_aesi changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_summary()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("flag_var_aesi-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_events_summary.R
+++ b/tests/testthat/test-shinytest2-tm_t_events_summary.R
@@ -142,7 +142,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_summary()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -168,7 +173,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_summary()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("flag_var_anl-dataset_ADAE_singleextract-select", c("TMPFL_REL", "TMPFL_GR5"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -182,7 +192,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_summary()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("flag_var_anl-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -196,7 +211,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_summary()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("flag_var_aesi-dataset_ADAE_singleextract-select", c("TMP_SMQ02", "TMP_CQ01"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -210,7 +230,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events_summary()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("flag_var_aesi-dataset_ADAE_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_exposure.R
+++ b/tests/testthat/test-shinytest2-tm_t_exposure.R
@@ -115,23 +115,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_exposure: Selecting paramcd-level changes the table and does not throw validation errors.",
+  "e2e - tm_t_exposure: Selecting paramcd changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_exposure()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADEX_singleextract-filter1-vals", "DOSE")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_exposure: Deselection of paramcd-level throws validation error.", {
+testthat::test_that("e2e - tm_t_exposure: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_exposure()
   app_driver$set_active_module_input("paramcd-dataset_ADEX_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -143,23 +143,23 @@ testthat::test_that("e2e - tm_t_exposure: Deselection of paramcd-level throws va
 })
 
 testthat::test_that(
-  "e2e - tm_t_exposure: Selecting parcat-level changes the table and does not throw validation errors.",
+  "e2e - tm_t_exposure: Selecting parcat changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_exposure()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("parcat-dataset_ADEX_singleextract-filter1-vals", "Drug B")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_exposure: Deselection of parcat-level throws validation error.", {
+testthat::test_that("e2e - tm_t_exposure: Deselection of parcat throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_exposure()
   app_driver$set_active_module_input("parcat-dataset_ADEX_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -171,49 +171,49 @@ testthat::test_that("e2e - tm_t_exposure: Deselection of parcat-level throws val
 })
 
 testthat::test_that(
-  "e2e - tm_t_exposure: Selecting col_by_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_exposure: Selecting col_by_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_exposure()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("col_by_var-dataset_ADSL_singleextract-select", "ARM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_exposure: Deselection of col_by_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_exposure: Deselection of col_by_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_exposure()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("col_by_var-dataset_ADSL_singleextract-select", character(0), wait_ = FALSE)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_exposure: Selecting row_by_var_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_exposure: Selecting row_by_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_exposure()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("row_by_var-dataset_ADEX_singleextract-select", "REGION1")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_exposure: Deselection of row_by_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_exposure: Deselection of row_by_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_exposure()
   app_driver$set_active_module_input("row_by_var-dataset_ADEX_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(

--- a/tests/testthat/test-shinytest2-tm_t_exposure.R
+++ b/tests/testthat/test-shinytest2-tm_t_exposure.R
@@ -121,7 +121,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_exposure()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADEX_singleextract-filter1-vals", "DOSE")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -149,7 +154,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_exposure()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("parcat-dataset_ADEX_singleextract-filter1-vals", "Drug B")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -177,7 +187,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_exposure()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("col_by_var-dataset_ADSL_singleextract-select", "ARM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -190,7 +205,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_exposure()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("col_by_var-dataset_ADSL_singleextract-select", character(0), wait_ = FALSE)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -203,7 +223,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_exposure()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("row_by_var-dataset_ADEX_singleextract-select", "REGION1")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_logistic.R
+++ b/tests/testthat/test-shinytest2-tm_t_logistic.R
@@ -66,7 +66,7 @@ testthat::test_that("e2e - tm_t_logistic: Module initializes in teal without err
 
 testthat::test_that(
   "e2e - tm_t_logistic: Starts with specified label, paramcd, responders, arm_var, buckets,
-  cov_var, interaction_var, conf_level, combine_comp_arms",
+  cov_var, interaction_var, conf_level, combine_comp_arms.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_logistic()
@@ -108,23 +108,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_logistic: Selecting paramcd-level changes the table and does not throw validation errors.",
+  "e2e - tm_t_logistic: Selecting paramcd changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_logistic()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADRS_singleextract-filter1-vals", "INVET")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_logistic: Deselection of paramcd-level throws validation error.", {
+testthat::test_that("e2e - tm_t_logistic: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_logistic()
   app_driver$set_active_module_input("paramcd-dataset_ADRS_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -136,23 +136,23 @@ testthat::test_that("e2e - tm_t_logistic: Deselection of paramcd-level throws va
 })
 
 testthat::test_that(
-  "e2e - tm_t_logistic: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_logistic: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_logistic()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_logistic: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_logistic: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_logistic()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -162,23 +162,23 @@ testthat::test_that("e2e - tm_t_logistic: Deselection of arm_var-variable throws
 })
 
 testthat::test_that(
-  "e2e - tm_t_logistic: Selecting cov_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_logistic: Selecting cov_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_logistic()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("cov_var-dataset_ADRS_singleextract-select", c("AGE", "BMRKR1"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_logistic: Deselection of cov_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_logistic: Deselection of cov_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_logistic()
   app_driver$set_active_module_input("cov_var-dataset_ADRS_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("cov_var-dataset_ADRS_singleextract-select_input .shiny-validation-message"),

--- a/tests/testthat/test-shinytest2-tm_t_logistic.R
+++ b/tests/testthat/test-shinytest2-tm_t_logistic.R
@@ -114,7 +114,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_logistic()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADRS_singleextract-filter1-vals", "INVET")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -142,7 +147,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_logistic()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -168,7 +178,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_logistic()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("cov_var-dataset_ADRS_singleextract-select", c("AGE", "BMRKR1"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_mult_events.R
+++ b/tests/testthat/test-shinytest2-tm_t_mult_events.R
@@ -51,7 +51,7 @@ testthat::test_that("e2e - tm_t_mult_events: Module initializes in teal without 
 })
 
 testthat::test_that(
-  "e2e - tm_t_mult_events: Starts with specified label, arm_var, hlt, llt, add_total, drop_arm_levels",
+  "e2e - tm_t_mult_events: Starts with specified label, arm_var, hlt, llt, add_total, drop_arm_levels.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_mult_events()
@@ -78,23 +78,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_mult_events: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_mult_events: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_mult_events()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_mult_events: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_mult_events: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_mult_events()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -104,32 +104,32 @@ testthat::test_that("e2e - tm_t_mult_events: Deselection of arm_var-variable thr
 })
 
 testthat::test_that(
-  "e2e - tm_t_mult_events: Selecting hlt-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_mult_events: Selecting hlt changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_mult_events()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADCM_singleextract-select", c("ATC1", "ATC2"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_mult_events: Deselection of hlt-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_mult_events: Deselection of hlt changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_mult_events()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADCM_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_mult_events: Deselection of llt-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_mult_events: Deselection of llt throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_mult_events()
   app_driver$set_active_module_input("llt-dataset_ADCM_singleextract-select", NULL)

--- a/tests/testthat/test-shinytest2-tm_t_mult_events.R
+++ b/tests/testthat/test-shinytest2-tm_t_mult_events.R
@@ -84,7 +84,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_mult_events()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -110,7 +115,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_mult_events()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADCM_singleextract-select", c("ATC1", "ATC2"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -123,7 +133,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_mult_events()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("hlt-dataset_ADCM_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_pp_basic_info.R
+++ b/tests/testthat/test-shinytest2-tm_t_pp_basic_info.R
@@ -33,7 +33,7 @@ testthat::test_that("e2e - tm_t_pp_basic_info: Module initializes in teal withou
   app_driver$stop()
 })
 
-testthat::test_that("e2e - tm_t_pp_basic_info: Starts with specified label, patient_id, vars", {
+testthat::test_that("e2e - tm_t_pp_basic_info: Starts with specified label, patient_id, vars.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_basic_info()
   testthat::expect_equal(
@@ -52,27 +52,16 @@ testthat::test_that("e2e - tm_t_pp_basic_info: Starts with specified label, pati
 })
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_t_pp_basic_info: Selecting patient_id",
-    "changes the table and does not throw validation errors."
-  ),
+  "e2e - tm_t_pp_basic_info: Selecting patient_id changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_basic_info()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(
-        app_driver$active_module_element("basic_info_table")
-      )
-    )[[1]]
+    table_before <- app_driver$get_active_module_table_output("basic_info_table")
     app_driver$set_active_module_input("patient_id", "AB12345-USA-1-id-261")
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(
-          app_driver$get_html_rvest(
-            app_driver$active_module_element("basic_info_table")
-          )
-        )[[1]]
+        app_driver$get_active_module_table_output("basic_info_table")
       )
     )
     app_driver$expect_no_validation_error()
@@ -81,10 +70,7 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_t_pp_basic_info: Deselection of patient_id",
-    "throws validation error and table is not visible"
-  ),
+  "e2e - tm_t_pp_basic_info: Deselection of patient_id throws validation error and table is not visible.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_basic_info()
@@ -105,18 +91,11 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  paste0(
-    "e2e - tm_t_pp_basic_info: Selecting cov_var-variable changes",
-    "the table and does not throw validation errors."
-  ),
+  "e2e - tm_t_pp_basic_info: Selecting cov_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_basic_info()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(
-        app_driver$active_module_element("basic_info_table")
-      )
-    )[[1]]
+    table_before <- app_driver$get_active_module_table_output("basic_info_table")
     app_driver$set_active_module_input(
       "vars-dataset_ADSL_singleextract-select",
       c("AGE", "BMRKR1")
@@ -124,11 +103,7 @@ testthat::test_that(
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(
-          app_driver$get_html_rvest(
-            app_driver$active_module_element("basic_info_table")
-          )
-        )[[1]]
+        app_driver$get_active_module_table_output("basic_info_table")
       )
     )
     app_driver$expect_no_validation_error()
@@ -136,7 +111,7 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_basic_info: Deselection of cov_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_basic_info: Deselection of cov_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_basic_info()
   app_driver$set_active_module_input("vars-dataset_ADSL_singleextract-select", NULL)

--- a/tests/testthat/test-shinytest2-tm_t_pp_laboratory.R
+++ b/tests/testthat/test-shinytest2-tm_t_pp_laboratory.R
@@ -59,7 +59,7 @@ testthat::test_that("e2e - tm_t_pp_laboratory: Module initializes in teal withou
 
 testthat::test_that(
   "e2e - tm_t_pp_laboratory: Starts with specified label, patient_id, paramcd, param,
-  timepoints, aval_var, avalu_var, anrind, round_value",
+  timepoints, aval_var, avalu_var, anrind, round_value.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_laboratory()
@@ -109,14 +109,12 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_laboratory()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table"))
-    )[[2]]
+    table_before <- app_driver$get_active_module_table_output("lab_values_table", which = 2)
     app_driver$set_active_module_input("patient_id", "AB12345-USA-1-id-261")
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table")))[[2]]
+        app_driver$get_active_module_table_output("lab_values_table", which = 2)
       )
     )
     app_driver$expect_no_validation_error()
@@ -143,19 +141,17 @@ testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of patient_id throws 
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_laboratory: Selecting paramcd-level changes the table
+  "e2e - tm_t_pp_laboratory: Selecting paramcd changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_laboratory()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table"))
-    )[[2]]
+    table_before <- app_driver$get_active_module_table_output("lab_values_table", which = 2)
     app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-select", "STUDYID")
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table")))[[2]]
+        app_driver$get_active_module_table_output("lab_values_table", which = 2)
       )
     )
     app_driver$expect_no_validation_error()
@@ -163,7 +159,7 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of paramcd-level throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_laboratory()
   app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-select", NULL)
@@ -182,19 +178,17 @@ testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of paramcd-level thro
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_laboratory: Selecting param-variable changes the table
+  "e2e - tm_t_pp_laboratory: Selecting param changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_laboratory()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table"))
-    )[[2]]
+    table_before <- app_driver$get_active_module_table_output("lab_values_table", which = 2)
     app_driver$set_active_module_input("param-dataset_ADLB_singleextract-select", "SEX")
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table")))[[2]]
+        app_driver$get_active_module_table_output("lab_values_table", which = 2)
       )
     )
     app_driver$expect_no_validation_error()
@@ -203,7 +197,7 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_pp_laboratory: Deselection of param-variable throws validation error.",
+  "e2e - tm_t_pp_laboratory: Deselection of param throws validation error.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_laboratory()
@@ -224,19 +218,17 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_pp_laboratory: Selecting timepoints-variable changes the table
+  "e2e - tm_t_pp_laboratory: Selecting timepoints changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_laboratory()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table"))
-    )[[2]]
+    table_before <- app_driver$get_active_module_table_output("lab_values_table", which = 2)
     app_driver$set_active_module_input("timepoints-dataset_ADLB_singleextract-select", "AGE")
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table")))[[2]]
+        app_driver$get_active_module_table_output("lab_values_table", which = 2)
       )
     )
     app_driver$expect_no_validation_error()
@@ -244,7 +236,7 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of timepoints-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of timepoints throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_laboratory()
   app_driver$set_active_module_input("timepoints-dataset_ADLB_singleextract-select", NULL)
@@ -265,19 +257,17 @@ testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of timepoints-variabl
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_laboratory: Selecting avalu-variable changes the table
+  "e2e - tm_t_pp_laboratory: Selecting avalu changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_laboratory()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table"))
-    )[[2]]
+    table_before <- app_driver$get_active_module_table_output("lab_values_table", which = 2)
     app_driver$set_active_module_input("avalu_var-dataset_ADLB_singleextract-select", "SEX")
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table")))[[2]]
+        app_driver$get_active_module_table_output("lab_values_table", which = 2)
       )
     )
     app_driver$expect_no_validation_error()
@@ -285,7 +275,7 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of avalu-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of avalu throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_laboratory()
   app_driver$set_active_module_input("avalu_var-dataset_ADLB_singleextract-select", NULL)
@@ -306,19 +296,17 @@ testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of avalu-variable thr
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_laboratory: Selecting aval_var-variable changes the table
+  "e2e - tm_t_pp_laboratory: Selecting aval_var changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_laboratory()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table"))
-    )[[2]]
+    table_before <- app_driver$get_active_module_table_output("lab_values_table", which = 2)
     app_driver$set_active_module_input("aval_var-dataset_ADLB_singleextract-select", "AGE")
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table")))[[2]]
+        app_driver$get_active_module_table_output("lab_values_table", which = 2)
       )
     )
     app_driver$expect_no_validation_error()
@@ -326,7 +314,7 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of aval_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of aval_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_laboratory()
   app_driver$set_active_module_input("aval_var-dataset_ADLB_singleextract-select", NULL)
@@ -345,19 +333,17 @@ testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of aval_var-variable 
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_laboratory: Selecting arind-variable changes the table
+  "e2e - tm_t_pp_laboratory: Selecting arind changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_laboratory()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table"))
-    )[[2]]
+    table_before <- app_driver$get_active_module_table_output("lab_values_table", which = 2)
     app_driver$set_active_module_input("anrind-dataset_ADLB_singleextract-select", "AGEU")
     testthat::expect_false(
       identical(
         table_before,
-        rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("lab_values_table")))[[2]]
+        app_driver$get_active_module_table_output("lab_values_table", which = 2)
       )
     )
     app_driver$expect_no_validation_error()
@@ -365,7 +351,7 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of arind-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_laboratory: Deselection of arind throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_laboratory()
   app_driver$set_active_module_input("anrind-dataset_ADLB_singleextract-select", NULL)

--- a/tests/testthat/test-shinytest2-tm_t_pp_medical_history.R
+++ b/tests/testthat/test-shinytest2-tm_t_pp_medical_history.R
@@ -81,9 +81,9 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_medical_history()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("patient_id", "AB12345-USA-1-id-45")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -93,7 +93,7 @@ testthat::test_that("e2e - tm_t_pp_medical_history: Deselection of patient_id th
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_medical_history()
   app_driver$set_active_module_input("patient_id", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("patient_id_input .shiny-validation-message"),
@@ -103,22 +103,23 @@ testthat::test_that("e2e - tm_t_pp_medical_history: Deselection of patient_id th
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_medical_history: Selecting mhterm-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_pp_medical_history: Selecting mhterm changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_medical_history()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("mhterm-dataset_ADMH_singleextract-select", "STUDYID")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_medical_history: Deselection of mhterm-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_medical_history: Deselection of mhterm throws validation error.", {
+  skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_medical_history()
   app_driver$set_active_module_input("mhterm-dataset_ADMH_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("mhterm-dataset_ADMH_singleextract-select_input .shiny-validation-message"),
@@ -128,22 +129,23 @@ testthat::test_that("e2e - tm_t_pp_medical_history: Deselection of mhterm-variab
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_medical_history: Selecting mhbodsys-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_pp_medical_history: Selecting mhbodsys changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_medical_history()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("mhbodsys-dataset_ADMH_singleextract-select", "EOSSTT")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_medical_history: Deselection of mhbodsys-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_medical_history: Deselection of mhbodsys throws validation error.", {
+  skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_medical_history()
   app_driver$set_active_module_input("mhbodsys-dataset_ADMH_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("mhbodsys-dataset_ADMH_singleextract-select_input .shiny-validation-message"),
@@ -153,22 +155,23 @@ testthat::test_that("e2e - tm_t_pp_medical_history: Deselection of mhbodsys-vari
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_medical_history: Selecting mhbodsys-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_pp_medical_history: Selecting mhbodsys changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_medical_history()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("mhdistat-dataset_ADMH_singleextract-select", "STUDYID")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_medical_history: Deselection of mhdistat-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_medical_history: Deselection of mhdistat throws validation error.", {
+  skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_medical_history()
   app_driver$set_active_module_input("mhdistat-dataset_ADMH_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("mhdistat-dataset_ADMH_singleextract-select_input .shiny-validation-message"),

--- a/tests/testthat/test-shinytest2-tm_t_pp_medical_history.R
+++ b/tests/testthat/test-shinytest2-tm_t_pp_medical_history.R
@@ -83,7 +83,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_pp_medical_history()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("patient_id", "AB12345-USA-1-id-45")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -109,7 +114,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_pp_medical_history()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("mhterm-dataset_ADMH_singleextract-select", "STUDYID")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -135,7 +145,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_pp_medical_history()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("mhbodsys-dataset_ADMH_singleextract-select", "EOSSTT")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -161,7 +176,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_pp_medical_history()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("mhdistat-dataset_ADMH_singleextract-select", "STUDYID")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_pp_prior_medication.R
+++ b/tests/testthat/test-shinytest2-tm_t_pp_prior_medication.R
@@ -96,14 +96,12 @@ testthat::test_that(
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_prior_medication()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("prior_medication_table"))
-    )[[1]]
+    table_before <- app_driver$get_active_module_table_output("prior_medication_table")
     app_driver$set_active_module_input("patient_id", "AB12345-USA-1-id-261")
     testthat::expect_false(
       identical(
         nrow(table_before),
-        nrow(rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("prior_medication_table"))))
+        nrow(app_driver$get_active_module_table_output("prior_medication_table"))
       )
     )
     app_driver$expect_no_validation_error()
@@ -124,18 +122,16 @@ testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of patient_id t
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_prior_medication: Selecting cmdecod-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_pp_prior_medication: Selecting cmdecod changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_prior_medication()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("prior_medication_table"))
-    )[[1]]
+    table_before <- app_driver$get_active_module_table_output("prior_medication_table")
     app_driver$set_active_module_input("cmdecod-dataset_ADCM_singleextract-select", "RACE")
     testthat::expect_false(
       identical(
         nrow(table_before),
-        nrow(rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("prior_medication_table"))))
+        nrow(app_driver$get_active_module_table_output("prior_medication_table"))
       )
     )
     app_driver$expect_no_validation_error()
@@ -143,7 +139,7 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of cmdecod-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of cmdecod throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_prior_medication()
   app_driver$set_active_module_input("cmdecod-dataset_ADCM_singleextract-select", NULL)
@@ -156,18 +152,16 @@ testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of cmdecod-vari
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_prior_medication: Selecting atirel-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_pp_prior_medication: Selecting atirel changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_prior_medication()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("prior_medication_table"))
-    )[[1]]
+    table_before <- app_driver$get_active_module_table_output("prior_medication_table")
     app_driver$set_active_module_input("atirel-dataset_ADCM_singleextract-select", "SEX")
     testthat::expect_false(
       identical(
         nrow(table_before),
-        nrow(rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("prior_medication_table"))))
+        nrow(app_driver$get_active_module_table_output("prior_medication_table"))
       )
     )
     app_driver$expect_no_validation_error()
@@ -175,7 +169,7 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of atirel-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of atirel throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_prior_medication()
   app_driver$set_active_module_input("atirel-dataset_ADCM_singleextract-select", NULL)
@@ -188,18 +182,16 @@ testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of atirel-varia
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_prior_medication: Selecting cmdecod-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_pp_prior_medication: Selecting cmdecod changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_prior_medication()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("prior_medication_table"))
-    )[[1]]
+    table_before <- app_driver$get_active_module_table_output("prior_medication_table")
     app_driver$set_active_module_input("cmindc-dataset_ADCM_singleextract-select", "SEX")
     testthat::expect_false(
       identical(
         nrow(table_before),
-        nrow(rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("prior_medication_table"))))
+        nrow(app_driver$get_active_module_table_output("prior_medication_table"))
       )
     )
     app_driver$expect_no_validation_error()
@@ -207,7 +199,7 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of cmindc-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of cmindc throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_prior_medication()
   app_driver$set_active_module_input("cmindc-dataset_ADCM_singleextract-select", NULL)
@@ -220,18 +212,16 @@ testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of cmindc-varia
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_prior_medication: Selecting cmdecod-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_pp_prior_medication: Selecting cmdecod changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_prior_medication()
-    table_before <- rvest::html_table(
-      app_driver$get_html_rvest(app_driver$active_module_element("prior_medication_table"))
-    )[[1]]
+    table_before <- app_driver$get_active_module_table_output("prior_medication_table")
     app_driver$set_active_module_input("cmstdy-dataset_ADCM_singleextract-select", "AGE")
     testthat::expect_false(
       identical(
         nrow(table_before),
-        nrow(rvest::html_table(app_driver$get_html_rvest(app_driver$active_module_element("prior_medication_table"))))
+        nrow(app_driver$get_active_module_table_output("prior_medication_table"))
       )
     )
     app_driver$expect_no_validation_error()
@@ -239,7 +229,7 @@ testthat::test_that(
   }
 )
 
-testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of cmstdy-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of cmstdy throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_prior_medication()
   app_driver$set_active_module_input("cmstdy-dataset_ADCM_singleextract-select", NULL)

--- a/tests/testthat/test-shinytest2-tm_t_pp_prior_medication.R
+++ b/tests/testthat/test-shinytest2-tm_t_pp_prior_medication.R
@@ -130,8 +130,8 @@ testthat::test_that(
     app_driver$set_active_module_input("cmdecod-dataset_ADCM_singleextract-select", "RACE")
     testthat::expect_false(
       identical(
-        nrow(table_before),
-        nrow(app_driver$get_active_module_table_output("prior_medication_table"))
+        table_before,
+        app_driver$get_active_module_table_output("prior_medication_table")
       )
     )
     app_driver$expect_no_validation_error()
@@ -160,8 +160,8 @@ testthat::test_that(
     app_driver$set_active_module_input("atirel-dataset_ADCM_singleextract-select", "SEX")
     testthat::expect_false(
       identical(
-        nrow(table_before),
-        nrow(app_driver$get_active_module_table_output("prior_medication_table"))
+        table_before,
+        app_driver$get_active_module_table_output("prior_medication_table")
       )
     )
     app_driver$expect_no_validation_error()
@@ -182,7 +182,7 @@ testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of atirel throw
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_prior_medication: Selecting cmdecod changes the table and does not throw validation errors.",
+  "e2e - tm_t_pp_prior_medication: Selecting cmindc changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_prior_medication()
@@ -190,8 +190,8 @@ testthat::test_that(
     app_driver$set_active_module_input("cmindc-dataset_ADCM_singleextract-select", "SEX")
     testthat::expect_false(
       identical(
-        nrow(table_before),
-        nrow(app_driver$get_active_module_table_output("prior_medication_table"))
+        table_before,
+        app_driver$get_active_module_table_output("prior_medication_table")
       )
     )
     app_driver$expect_no_validation_error()
@@ -212,7 +212,7 @@ testthat::test_that("e2e - tm_t_pp_prior_medication: Deselection of cmindc throw
 })
 
 testthat::test_that(
-  "e2e - tm_t_pp_prior_medication: Selecting cmdecod changes the table and does not throw validation errors.",
+  "e2e - tm_t_pp_prior_medication: Selecting cmstdy changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_prior_medication()
@@ -220,8 +220,8 @@ testthat::test_that(
     app_driver$set_active_module_input("cmstdy-dataset_ADCM_singleextract-select", "AGE")
     testthat::expect_false(
       identical(
-        nrow(table_before),
-        nrow(app_driver$get_active_module_table_output("prior_medication_table"))
+        table_before,
+        app_driver$get_active_module_table_output("prior_medication_table")
       )
     )
     app_driver$expect_no_validation_error()

--- a/tests/testthat/test-shinytest2-tm_t_shift_by_arm.R
+++ b/tests/testthat/test-shinytest2-tm_t_shift_by_arm.R
@@ -98,23 +98,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_shift_by_arm: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_shift_by_arm: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_arm()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_shift_by_arm: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_shift_by_arm: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_shift_by_arm()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -124,23 +124,23 @@ testthat::test_that("e2e - tm_t_shift_by_arm: Deselection of arm_var-variable th
 })
 
 testthat::test_that(
-  "e2e - tm_t_shift_by_arm: Selecting paramcd-level changes the table and does not throw validation errors.",
+  "e2e - tm_t_shift_by_arm: Selecting paramcd changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_arm()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADEG_singleextract-filter1-vals", "QT")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_shift_by_arm: Deselection of paramcd-level throws validation error.", {
+testthat::test_that("e2e - tm_t_shift_by_arm: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_shift_by_arm()
   app_driver$set_active_module_input("paramcd-dataset_ADEG_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -152,23 +152,23 @@ testthat::test_that("e2e - tm_t_shift_by_arm: Deselection of paramcd-level throw
 })
 
 testthat::test_that(
-  "e2e - tm_t_shift_by_arm: Selecting visit_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_shift_by_arm: Selecting visit_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_arm()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("visit_var-dataset_ADEG_singleextract-filter1-vals", "SCREENING")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_shift_by_arm: Deselection of visit_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_shift_by_arm: Deselection of visit_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_shift_by_arm()
   app_driver$set_active_module_input("visit_var-dataset_ADEG_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(

--- a/tests/testthat/test-shinytest2-tm_t_shift_by_arm.R
+++ b/tests/testthat/test-shinytest2-tm_t_shift_by_arm.R
@@ -104,7 +104,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_arm()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -130,7 +135,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_arm()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADEG_singleextract-filter1-vals", "QT")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -158,7 +168,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_arm()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("visit_var-dataset_ADEG_singleextract-filter1-vals", "SCREENING")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_shift_by_arm_by_worst.R
+++ b/tests/testthat/test-shinytest2-tm_t_shift_by_arm_by_worst.R
@@ -117,7 +117,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -143,7 +148,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADEG_singleextract-filter1-vals", "HR")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -172,7 +182,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("worst_flag_var-dataset_ADEG_singleextract-select", "WORS01FL")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -201,7 +216,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("aval_var-dataset_ADEG_singleextract-select", "AVALC")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -228,7 +248,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("baseline_var-dataset_ADEG_singleextract-select", "BASEC")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_shift_by_arm_by_worst.R
+++ b/tests/testthat/test-shinytest2-tm_t_shift_by_arm_by_worst.R
@@ -110,24 +110,24 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_shift_by_arm_by_worst: Selecting arm_var-variable changes the table
+  "e2e - tm_t_shift_by_arm_by_worst: Selecting arm_var changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -137,23 +137,23 @@ testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of arm_var-va
 })
 
 testthat::test_that(
-  "e2e - tm_t_shift_by_arm_by_worst: Selecting paramcd-level changes the table and does not throw validation errors.",
+  "e2e - tm_t_shift_by_arm_by_worst: Selecting paramcd changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADEG_singleextract-filter1-vals", "HR")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of paramcd-level throws validation error.", {
+testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
   app_driver$set_active_module_input("paramcd-dataset_ADEG_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -165,24 +165,24 @@ testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of paramcd-le
 })
 
 testthat::test_that(
-  "e2e - tm_t_shift_by_arm_by_worst: Selecting worst_flag-variable changes the table
+  "e2e - tm_t_shift_by_arm_by_worst: Selecting worst_flag changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("worst_flag_var-dataset_ADEG_singleextract-select", "WORS01FL")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of worst_flag-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of worst_flag throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
   app_driver$set_active_module_input("worst_flag_var-dataset_ADEG_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -194,24 +194,24 @@ testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of worst_flag
 })
 
 testthat::test_that(
-  "e2e - tm_t_shift_by_arm_by_worst: Selecting aval_var-variable changes the table
+  "e2e - tm_t_shift_by_arm_by_worst: Selecting aval_var changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("aval_var-dataset_ADEG_singleextract-select", "AVALC")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of aval_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of aval_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
   app_driver$set_active_module_input("aval_var-dataset_ADEG_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("aval_var-dataset_ADEG_singleextract-select_input .shiny-validation-message"),
@@ -221,24 +221,24 @@ testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of aval_var-v
 })
 
 testthat::test_that(
-  "e2e - tm_t_shift_by_arm_by_worst: Selecting baseline_var-variable changes the table
+  "e2e - tm_t_shift_by_arm_by_worst: Selecting baseline_var changes the table
   and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("baseline_var-dataset_ADEG_singleextract-select", "BASEC")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of baseline_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_shift_by_arm_by_worst: Deselection of baseline_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
   app_driver$set_active_module_input("baseline_var-dataset_ADEG_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(

--- a/tests/testthat/test-shinytest2-tm_t_shift_by_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_shift_by_grade.R
@@ -121,23 +121,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_shift_by_grade: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_shift_by_grade: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_shift_by_grade: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_shift_by_grade: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_shift_by_grade()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -147,23 +147,23 @@ testthat::test_that("e2e - tm_t_shift_by_grade: Deselection of arm_var-variable 
 })
 
 testthat::test_that(
-  "e2e - tm_t_shift_by_grade: Selecting paramcd-level changes the table and does not throw validation errors.",
+  "e2e - tm_t_shift_by_grade: Selecting paramcd changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-filter1-vals", "CRP")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_shift_by_grade: Deselection of paramcd-level throws validation error.", {
+testthat::test_that("e2e - tm_t_shift_by_grade: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_shift_by_grade()
   app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -175,23 +175,23 @@ testthat::test_that("e2e - tm_t_shift_by_grade: Deselection of paramcd-level thr
 })
 
 testthat::test_that(
-  "e2e - tm_t_shift_by_grade: Selecting worst_flag-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_shift_by_grade: Selecting worst_flag changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_grade()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("worst_flag_var-dataset_ADLB_singleextract-select", "WGRLOFL")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_shift_by_grade: Deselection of worst_flag-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_shift_by_grade: Deselection of worst_flag throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_shift_by_grade()
   app_driver$set_active_module_input("worst_flag_var-dataset_ADLB_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(

--- a/tests/testthat/test-shinytest2-tm_t_shift_by_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_shift_by_grade.R
@@ -127,7 +127,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -153,7 +158,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-filter1-vals", "CRP")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -181,7 +191,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_grade()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("worst_flag_var-dataset_ADLB_singleextract-select", "WGRLOFL")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_smq.R
+++ b/tests/testthat/test-shinytest2-tm_t_smq.R
@@ -105,7 +105,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_smq()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "SEX")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -129,7 +134,12 @@ testthat::test_that("e2e - tm_t_smq: Selecting paramcd changes the table and doe
   app_driver <- app_driver_tm_t_smq()
   table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input("llt-dataset_ADAE_singleextract-select", "SEX")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+  testthat::expect_false(
+    identical(
+      table_before,
+      app_driver$get_active_module_table_output("table-table-with-settings")
+    )
+  )
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
@@ -154,7 +164,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_smq()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("baskets-dataset_ADAE_singleextract-select", "CQ01NAM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_smq.R
+++ b/tests/testthat/test-shinytest2-tm_t_smq.R
@@ -68,7 +68,7 @@ testthat::test_that("e2e - tm_t_smq: Module initializes in teal without errors a
 })
 
 testthat::test_that(
-  "e2e - tm_t_smq: Starts with specified label, arm_var, llt, baskets, sort_criteria, add_total, drop_arm_levels",
+  "e2e - tm_t_smq: Starts with specified label, arm_var, llt, baskets, sort_criteria, add_total, drop_arm_levels.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_smq()
@@ -99,23 +99,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_smq: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_smq: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_smq()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "SEX")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_smq: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_smq: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_smq()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -124,21 +124,21 @@ testthat::test_that("e2e - tm_t_smq: Deselection of arm_var-variable throws vali
   app_driver$stop()
 })
 
-testthat::test_that("e2e - tm_t_smq: Selecting paramcd-level changes the table and does not throw validation errors.", {
+testthat::test_that("e2e - tm_t_smq: Selecting paramcd changes the table and does not throw validation errors.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_smq()
-  table_before <- app_driver$get_active_module_tws_output("table")
+  table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
   app_driver$set_active_module_input("llt-dataset_ADAE_singleextract-select", "SEX")
-  testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+  testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
   app_driver$expect_no_validation_error()
   app_driver$stop()
 })
 
-testthat::test_that("e2e - tm_t_smq: Deselection of paramcd-level throws validation error.", {
+testthat::test_that("e2e - tm_t_smq: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_smq()
   app_driver$set_active_module_input("llt-dataset_ADAE_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("llt-dataset_ADAE_singleextract-select_input .shiny-validation-message"),
@@ -148,23 +148,23 @@ testthat::test_that("e2e - tm_t_smq: Deselection of paramcd-level throws validat
 })
 
 testthat::test_that(
-  "e2e - tm_t_smq: Selecting worst_flag-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_smq: Selecting worst_flag changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_smq()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("baskets-dataset_ADAE_singleextract-select", "CQ01NAM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_smq: Deselection of worst_flag-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_smq: Deselection of worst_flag throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_smq()
   app_driver$set_active_module_input("baskets-dataset_ADAE_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("baskets-dataset_ADAE_singleextract-select_input .shiny-validation-message"),

--- a/tests/testthat/test-shinytest2-tm_t_summary.R
+++ b/tests/testthat/test-shinytest2-tm_t_summary.R
@@ -73,23 +73,23 @@ testthat::test_that("e2e - tm_t_summary: Starts with specified label, arm_var, s
 })
 
 testthat::test_that(
-  "e2e - tm_t_summary: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_summary: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_summary()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_summary: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_summary: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_summary()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -99,23 +99,23 @@ testthat::test_that("e2e - tm_t_summary: Deselection of arm_var-variable throws 
 })
 
 testthat::test_that(
-  "e2e - tm_t_summary: Selecting summarize_vars-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_summary: Selecting summarize_vars changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_summary()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("summarize_vars-dataset_ADSL_singleextract-select", c("SEX", "AGE"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_summary: Deselection of summarize_vars-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_summary: Deselection of summarize_vars throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_summary()
   app_driver$set_active_module_input("summarize_vars-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(

--- a/tests/testthat/test-shinytest2-tm_t_summary.R
+++ b/tests/testthat/test-shinytest2-tm_t_summary.R
@@ -79,7 +79,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_summary()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -105,7 +110,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_summary()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("summarize_vars-dataset_ADSL_singleextract-select", c("SEX", "AGE"))
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_summary_by.R
+++ b/tests/testthat/test-shinytest2-tm_t_summary_by.R
@@ -114,7 +114,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_summary_by()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -140,7 +145,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_summary_by()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-filter1-vals", "CRP")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -168,7 +178,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_summary_by()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("by_vars-dataset_ADLB_singleextract-select", "PARAM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -181,7 +196,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_summary_by()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("by_vars-dataset_ADLB_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -194,7 +214,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_summary_by()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("summarize_vars-dataset_ADLB_singleextract-select", "CHG")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_summary_by.R
+++ b/tests/testthat/test-shinytest2-tm_t_summary_by.R
@@ -108,23 +108,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_summary_by: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_summary_by: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_summary_by()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_summary_by: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_summary_by: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_summary_by()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text("arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"),
@@ -134,23 +134,23 @@ testthat::test_that("e2e - tm_t_summary_by: Deselection of arm_var-variable thro
 })
 
 testthat::test_that(
-  "e2e - tm_t_summary_by: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_summary_by: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_summary_by()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-filter1-vals", "CRP")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_summary_by: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_summary_by: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_summary_by()
   app_driver$set_active_module_input("paramcd-dataset_ADLB_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -162,49 +162,49 @@ testthat::test_that("e2e - tm_t_summary_by: Deselection of arm_var-variable thro
 })
 
 testthat::test_that(
-  "e2e - tm_t_summary_by: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_summary_by: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_summary_by()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("by_vars-dataset_ADLB_singleextract-select", "PARAM")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_summary_by: Deselection of arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_summary_by: Deselection of arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_summary_by()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("by_vars-dataset_ADLB_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_summary_by: Selecting summarize_vars-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_summary_by: Selecting summarize_vars changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_summary_by()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("summarize_vars-dataset_ADLB_singleextract-select", "CHG")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_summary_by: Deselection of summarize_vars-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_summary_by: Deselection of summarize_vars throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_summary_by()
   app_driver$set_active_module_input("summarize_vars-dataset_ADLB_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(

--- a/tests/testthat/test-shinytest2-tm_t_tte.R
+++ b/tests/testthat/test-shinytest2-tm_t_tte.R
@@ -155,23 +155,23 @@ testthat::test_that(
 )
 
 testthat::test_that(
-  "e2e - tm_t_tte: Selecting paramcd-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_tte: Selecting paramcd changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_tte()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADTTE_singleextract-filter1-vals", "CRSD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_tte: Deselection of paramcd-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_tte: Deselection of paramcd throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_tte()
   app_driver$set_active_module_input("paramcd-dataset_ADTTE_singleextract-filter1-vals", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -183,23 +183,23 @@ testthat::test_that("e2e - tm_t_tte: Deselection of paramcd-variable throws vali
 })
 
 testthat::test_that(
-  "e2e - tm_t_tte: Selecting arm_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_tte: Selecting arm_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_tte()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
-testthat::test_that("e2e - tm_t_tte: Deselection of arm_var-variable throws validation error.", {
+testthat::test_that("e2e - tm_t_tte: Deselection of arm_var throws validation error.", {
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_tte()
   app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", NULL)
-  testthat::expect_identical(app_driver$get_active_module_tws_output("table"), data.frame())
+  testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
     app_driver$active_module_element_text(
@@ -212,26 +212,26 @@ testthat::test_that("e2e - tm_t_tte: Deselection of arm_var-variable throws vali
 
 
 testthat::test_that(
-  "e2e - tm_t_tte: Selecting strata_var-variable changes the table and does not throw validation errors.",
+  "e2e - tm_t_tte: Selecting strata_var changes the table and does not throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_tte()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", "BMRKR2")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
 )
 
 testthat::test_that(
-  "e2e - tm_t_tte: Deselection of strata_var-variable changes the table and throw validation errors.",
+  "e2e - tm_t_tte: Deselection of strata_var changes the table and throw validation errors.",
   {
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_tte()
-    table_before <- app_driver$get_active_module_tws_output("table")
+    table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_tws_output("table")))
+    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }

--- a/tests/testthat/test-shinytest2-tm_t_tte.R
+++ b/tests/testthat/test-shinytest2-tm_t_tte.R
@@ -161,7 +161,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_tte()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("paramcd-dataset_ADTTE_singleextract-filter1-vals", "CRSD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -189,7 +194,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_tte()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("arm_var-dataset_ADSL_singleextract-select", "ARMCD")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -210,7 +220,6 @@ testthat::test_that("e2e - tm_t_tte: Deselection of arm_var throws validation er
   app_driver$stop()
 })
 
-
 testthat::test_that(
   "e2e - tm_t_tte: Selecting strata_var changes the table and does not throw validation errors.",
   {
@@ -218,7 +227,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_tte()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", "BMRKR2")
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }
@@ -231,7 +245,12 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_tte()
     table_before <- app_driver$get_active_module_table_output("table-table-with-settings")
     app_driver$set_active_module_input("strata_var-dataset_ADSL_singleextract-select", NULL)
-    testthat::expect_false(identical(table_before, app_driver$get_active_module_table_output("table-table-with-settings")))
+    testthat::expect_false(
+      identical(
+        table_before,
+        app_driver$get_active_module_table_output("table-table-with-settings")
+      )
+    )
     app_driver$expect_no_validation_error()
     app_driver$stop()
   }


### PR DESCRIPTION
- [x] Rename `get_active_module_pws_output` with `get_active_module_plot_output` respectively after https://github.com/insightsengineering/teal/pull/1210 is merged. @kartikeyakirar 
- [x] Rename `get_active_module_tws_output`  with `get_active_module_table_output` @vedhav 
- [x] Replace  `rvest::html_table()` and use `get_active_module_table_output` for DT tables. @kartikeyakirar  
- [x]  Check if all the tests have skip_if_too_deep(5) and app_driver$stop() @kartikeyakirar 
- [x]  Make sure the test description is standard: Begin with a Capital letter and end with . uses variables like arm_var instead of arm_var-variable or ARM variable @vedhav 
- [x]  Verify that all the module params are covered in the test. Especially check for cases with fixed data transform. (leave parameter with deprecated status) @kartikeyakirar 
- [x]  prefix teal.data:: for teal_data(), datanames() and join_keys where ever its missing. @kartikeyakirar 