### PR TITLE
Bumps `{rmarkdown}` minimal version

### DIFF
--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         test-strategy: ["min_cohort", "min_isolated", "release", "max"]
-    uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@alternative-mirror
+    uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@alternate_mirror
     name: Dependency Test - ${{ matrix.test-strategy }} 🔢
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         test-strategy: ["min_cohort", "min_isolated", "release", "max"]
-    uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@main
+    uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@alternative-mirror
     name: Dependency Test - ${{ matrix.test-strategy }} 🔢
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         test-strategy: ["min_cohort", "min_isolated", "release", "max"]
-    uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@alternate_mirror
+    uses: insightsengineering/r.pkg.template/.github/workflows/verdepcheck.yaml@main
     name: Dependency Test - ${{ matrix.test-strategy }} 🔢
     secrets:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Imports:
     lifecycle (>= 0.2.0),
     methods,
     rlistings (>= 0.2.8),
-    rmarkdown (>= 2.19),
+    rmarkdown (>= 2.23),
     rtables (>= 0.6.7),
     scales,
     shiny (>= 1.6.0),
@@ -66,7 +66,7 @@ Imports:
     vistime (>= 1.2.3)
 Suggests:
     forcats,
-    knitr (>= 1.34),
+    knitr (>= 1.42),
     logger (>= 0.2.0),
     lubridate (>= 1.7.9),
     nestcolor (>= 0.1.0),


### PR DESCRIPTION
# Pull Request

Part of https://github.com/insightsengineering/coredev-tasks/issues/546

Necessary bump to overcome a lack of binary on ppm snapshots that causes an error on minimum strategies for `scheduled` workflows.