### PR TITLE
Fix teal namespace for broken tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ BugReports:
     https://github.com/insightsengineering/teal.modules.clinical/issues
 Depends:
     R (>= 4.0),
-    teal (>= 0.15.2),
+    teal (>= 0.15.2.9052),
     teal.transform (>= 0.5.0),
     tern (>= 0.9.5.9011)
 Imports:

--- a/tests/testthat/test-shinytest2-tm_a_gee.R
+++ b/tests/testthat/test-shinytest2-tm_a_gee.R
@@ -61,7 +61,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_a_gee()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "GEE"
     )
 

--- a/tests/testthat/test-shinytest2-tm_a_mmrm.R
+++ b/tests/testthat/test-shinytest2-tm_a_mmrm.R
@@ -103,7 +103,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_a_mmrm(FALSE)
 
-    testthat::expect_equal(app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"), "MMRM")
+    testthat::expect_equal(app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"), "MMRM")
 
     testthat::expect_equal(app_driver$get_active_module_input("aval_var-dataset_ADQS_singleextract-select"), "AVAL")
 

--- a/tests/testthat/test-shinytest2-tm_g_barchart_simple.R
+++ b/tests/testthat/test-shinytest2-tm_g_barchart_simple.R
@@ -137,7 +137,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_barchart_simple()
 
     testthat::expect_equal(
-      trimws(app_driver$get_text("#teal-main_ui-root-active_tab > li.active")),
+      trimws(app_driver$get_text("#teal-teal_modules-active_tab > li.active")),
       "ADAE Analysis (e2e)"
     )
 

--- a/tests/testthat/test-shinytest2-tm_g_ci.R
+++ b/tests/testthat/test-shinytest2-tm_g_ci.R
@@ -86,7 +86,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_ci()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Confidence Interval Plot"
     )
 

--- a/tests/testthat/test-shinytest2-tm_g_forest_rsp.R
+++ b/tests/testthat/test-shinytest2-tm_g_forest_rsp.R
@@ -109,7 +109,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_forest_rsp()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Forest Response"
     )
 

--- a/tests/testthat/test-shinytest2-tm_g_forest_tte.R
+++ b/tests/testthat/test-shinytest2-tm_g_forest_tte.R
@@ -96,7 +96,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_forest_tte()
 
     testthat::expect_identical(
-      trimws(app_driver$get_text("#teal-main_ui-root-active_tab > li.active")),
+      trimws(app_driver$get_text("#teal-teal_modules-active_tab > li.active")),
       "Forest Survival (e2e)"
     )
 

--- a/tests/testthat/test-shinytest2-tm_g_ipp.R
+++ b/tests/testthat/test-shinytest2-tm_g_ipp.R
@@ -86,7 +86,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_ipp()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Individual Patient Plot"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_g_km.R
+++ b/tests/testthat/test-shinytest2-tm_g_km.R
@@ -98,7 +98,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_km()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Kaplan-Meier Plot"
     )
 

--- a/tests/testthat/test-shinytest2-tm_g_lineplot.R
+++ b/tests/testthat/test-shinytest2-tm_g_lineplot.R
@@ -86,7 +86,7 @@ testthat::test_that(
 
     app_driver <- app_driver_tm_g_lineplot()
 
-    testthat::expect_equal(trimws(app_driver$get_text("#teal-main_ui-root-active_tab > li.active")), "Line Plot")
+    testthat::expect_equal(trimws(app_driver$get_text("#teal-teal_modules-active_tab > li.active")), "Line Plot")
     testthat::expect_equal(app_driver$get_active_module_input("param-dataset_ADLB_singleextract-filter1-vals"), "ALT")
     testthat::expect_equal(app_driver$get_active_module_input("strata-dataset_ADSL_singleextract-select"), "ARM")
     testthat::expect_equal(app_driver$get_active_module_input("y-dataset_ADLB_singleextract-select"), "AVAL")

--- a/tests/testthat/test-shinytest2-tm_g_pp_adverse_events.R
+++ b/tests/testthat/test-shinytest2-tm_g_pp_adverse_events.R
@@ -75,7 +75,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_g_pp_adverse_events()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Adverse Events"
     )
 

--- a/tests/testthat/test-shinytest2-tm_g_pp_patient_timeline.R
+++ b/tests/testthat/test-shinytest2-tm_g_pp_patient_timeline.R
@@ -110,7 +110,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_pp_patient_timeline()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Patient Timeline"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_g_pp_therapy.R
+++ b/tests/testthat/test-shinytest2-tm_g_pp_therapy.R
@@ -113,7 +113,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_pp_therapy()
 
     testthat::expect_equal(
-      trimws(app_driver$get_text("#teal-main_ui-root-active_tab > li.active")),
+      trimws(app_driver$get_text("#teal-teal_modules-active_tab > li.active")),
       "Therapy (e2e)"
     )
 

--- a/tests/testthat/test-shinytest2-tm_g_pp_vitals.R
+++ b/tests/testthat/test-shinytest2-tm_g_pp_vitals.R
@@ -61,7 +61,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_g_pp_vitals()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Vitals"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_abnormality.R
+++ b/tests/testthat/test-shinytest2-tm_t_abnormality.R
@@ -82,7 +82,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_abnormality()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Abnormality Table"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_abnormality_by_worst_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_abnormality_by_worst_grade.R
@@ -80,7 +80,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_abnormality_by_worst_grade()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Laboratory Test Results with Highest Grade Post-Baseline"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_ancova.R
+++ b/tests/testthat/test-shinytest2-tm_t_ancova.R
@@ -80,7 +80,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_ancova()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "ANCOVA Table"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_binary_outcome.R
+++ b/tests/testthat/test-shinytest2-tm_t_binary_outcome.R
@@ -111,7 +111,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_binary_outcome()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Responders"
     )
     testthat::expect_equal(
@@ -227,7 +227,7 @@ testthat::test_that("e2e - tm_t_binary_outcome: Deselection of responders throws
   testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
   testthat::expect_equal(
-    app_driver$get_text("#teal-main_ui-root-responders .shiny-validation-message"),
+    app_driver$get_text("#teal-teal_modules-responders .shiny-validation-message"),
     "`Responders` field is empty"
   )
   app_driver$stop()

--- a/tests/testthat/test-shinytest2-tm_t_coxreg.R
+++ b/tests/testthat/test-shinytest2-tm_t_coxreg.R
@@ -76,7 +76,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_coxreg()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Cox Reg."
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_events.R
+++ b/tests/testthat/test-shinytest2-tm_t_events.R
@@ -59,7 +59,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_events()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Adverse Event Table"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_events_by_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_events_by_grade.R
@@ -72,7 +72,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_by_grade()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Adverse Events by Grade Table"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_events_patyear.R
+++ b/tests/testthat/test-shinytest2-tm_t_events_patyear.R
@@ -73,7 +73,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_patyear()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "AE Rate Adjusted for Patient-Years At Risk Table"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_events_summary.R
+++ b/tests/testthat/test-shinytest2-tm_t_events_summary.R
@@ -112,7 +112,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_events_summary()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Adverse Events Summary"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_exposure.R
+++ b/tests/testthat/test-shinytest2-tm_t_exposure.R
@@ -89,7 +89,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_exposure()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Duration of Exposure Table"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_logistic.R
+++ b/tests/testthat/test-shinytest2-tm_t_logistic.R
@@ -71,7 +71,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_logistic()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Logistic Regression"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_mult_events.R
+++ b/tests/testthat/test-shinytest2-tm_t_mult_events.R
@@ -56,7 +56,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_mult_events()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Concomitant Medications by Medication Class and Preferred Name"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_pp_basic_info.R
+++ b/tests/testthat/test-shinytest2-tm_t_pp_basic_info.R
@@ -37,7 +37,7 @@ testthat::test_that("e2e - tm_t_pp_basic_info: Starts with specified label, pati
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_pp_basic_info()
   testthat::expect_equal(
-    app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+    app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
     "Basic Info"
   )
   testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_pp_laboratory.R
+++ b/tests/testthat/test-shinytest2-tm_t_pp_laboratory.R
@@ -65,7 +65,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_pp_laboratory()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Vitals"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_pp_medical_history.R
+++ b/tests/testthat/test-shinytest2-tm_t_pp_medical_history.R
@@ -53,7 +53,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_pp_medical_history()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Medical History"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_pp_prior_medication.R
+++ b/tests/testthat/test-shinytest2-tm_t_pp_prior_medication.R
@@ -64,7 +64,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_pp_prior_medication()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Prior Medication"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_shift_by_arm.R
+++ b/tests/testthat/test-shinytest2-tm_t_shift_by_arm.R
@@ -69,7 +69,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_arm()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Shift by Arm Table"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_shift_by_arm_by_worst.R
+++ b/tests/testthat/test-shinytest2-tm_t_shift_by_arm_by_worst.R
@@ -73,7 +73,7 @@ testthat::test_that(
     app_driver <- app_driver_tm_t_shift_by_arm_by_worst()
 
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Shift by Arm Table"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_shift_by_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_shift_by_grade.R
@@ -86,7 +86,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_grade()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Grade Laboratory Abnormality Table"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_smq.R
+++ b/tests/testthat/test-shinytest2-tm_t_smq.R
@@ -73,7 +73,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_smq()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Adverse Events by SMQ Table"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_summary.R
+++ b/tests/testthat/test-shinytest2-tm_t_summary.R
@@ -50,7 +50,7 @@ testthat::test_that("e2e - tm_t_summary: Starts with specified label, arm_var, s
   skip_if_too_deep(5)
   app_driver <- app_driver_tm_t_summary()
   testthat::expect_equal(
-    app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+    app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
     "Demographic Table"
   )
   testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_summary_by.R
+++ b/tests/testthat/test-shinytest2-tm_t_summary_by.R
@@ -72,7 +72,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_summary_by()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Summary by Row Groups Table"
     )
     testthat::expect_equal(

--- a/tests/testthat/test-shinytest2-tm_t_tte.R
+++ b/tests/testthat/test-shinytest2-tm_t_tte.R
@@ -94,7 +94,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_tte()
     testthat::expect_equal(
-      app_driver$get_text("#teal-main_ui-root-active_tab > li.active > a"),
+      app_driver$get_text("#teal-teal_modules-active_tab > li.active > a"),
       "Time To Event Table"
     )
     testthat::expect_equal(


### PR DESCRIPTION
Fixes the `shinytest2` e2e tests failures due to namespace change in the refactor of teal.