### PR TITLE
fix: changed the separator in h_concat_expr

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -97,7 +97,7 @@ get_var_labels <- function(datasets, dataname, vars) {
 #' h_concat_expr(expr)
 h_concat_expr <- function(expr) {
   expr <- deparse(expr)
-  paste(expr, collapse = " ")
+  paste(expr, collapse = "\n")
 }
 
 

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -3,7 +3,7 @@
     Code
       res
     Output
-      [1] "rtables::basic_table() %>% rtables::split_cols_by(var = \"ARMCD\") %>%      tern::test_proportion_diff(vars = \"rsp\", method = \"cmh\",          variables = list(strata = \"strata\")) %>% rtables::build_table(df = dta)"
+      [1] "rtables::basic_table() %>% rtables::split_cols_by(var = \"ARMCD\") %>% \n    tern::test_proportion_diff(vars = \"rsp\", method = \"cmh\", \n        variables = list(strata = \"strata\")) %>% rtables::build_table(df = dta)"
 
 # add_expr adds expressions to expression list
 


### PR DESCRIPTION
* Changed the separator in `h_concat_expr` to `\n` to avoid generating unparsable code such as in this example:
```{r}
q <- quote({
  a <- 1
  for (i in 1:7) {}
})

unparsable <- teal.modules.clinical:::h_concat_expr(q)
print(unparsable)
str2lang(unparsable) # Parse error, unexpected for
```

* From what I could tell, this does not affect Show R Code outputs (surprisingly)
