### PR TITLE
Introduce decorators for `tm_t_coxreg`

### DIFF
--- a/R/tm_t_coxreg.R
+++ b/R/tm_t_coxreg.R
@@ -365,7 +365,7 @@ template_coxreg_m <- function(dataname,
 #' @section Decorating `tm_t_coxreg`:
 #'
 #' This module generates the following objects, which can be modified in place using decorators:
-#' - `plot` (`TableTree` as created from `rtables::build_table`)
+#' - `table` (`TableTree` as created from `rtables::build_table`)
 #'
 #' For additional details and examples of decorators, refer to the vignette
 #' `vignette("decorate-modules-output", package = "teal")` or the [`teal_transform_module()`] documentation.

--- a/R/tm_t_coxreg.R
+++ b/R/tm_t_coxreg.R
@@ -319,7 +319,6 @@ template_coxreg_m <- function(dataname,
 
   y$table <- quote({
     table <- rtables::build_table(lyt = lyt, df = anl)
-    table
   })
 
   y
@@ -1103,7 +1102,6 @@ srv_t_coxreg <- function(id,
 
     # Outputs to render.
     table_r <- reactive({
-      browser()
       decorated_table_q()[["table"]]})
 
     teal.widgets::table_with_settings_srv(

--- a/R/tm_t_coxreg.R
+++ b/R/tm_t_coxreg.R
@@ -161,9 +161,9 @@ template_coxreg_u <- function(dataname,
   )
 
   y$table <- if (append) {
-    quote(result <- c(result, rtables::build_table(lyt = lyt, df = anl)))
+    quote(table <- c(table, rtables::build_table(lyt = lyt, df = anl)))
   } else {
-    quote(result <- rtables::build_table(lyt = lyt, df = anl))
+    quote(table <- rtables::build_table(lyt = lyt, df = anl))
   }
 
   y
@@ -318,8 +318,8 @@ template_coxreg_m <- function(dataname,
   )
 
   y$table <- quote({
-    result <- rtables::build_table(lyt = lyt, df = anl)
-    result
+    table <- rtables::build_table(lyt = lyt, df = anl)
+    table
   })
 
   y
@@ -337,6 +337,7 @@ template_coxreg_m <- function(dataname,
 #' @inheritParams template_coxreg_m
 #' @param multivariate (`logical`)\cr if `FALSE`, the univariable approach is used instead of the
 #'   multi-variable model.
+#' @param decorators `r roxygen_decorators_param("tm_t_coxreg")`
 #'
 #' @details
 #' The Cox Proportional Hazards (PH) model is the most commonly used method to
@@ -360,6 +361,14 @@ template_coxreg_m <- function(dataname,
 #' * Multi-variable is the default choice for backward compatibility.
 #'
 #' @inherit module_arguments return seealso
+#'
+#' @section Decorating `tm_t_coxreg`:
+#'
+#' This module generates the following objects, which can be modified in place using decorators:
+#' - `plot` (`TableTree` as created from `rtables::build_table`)
+#'
+#' For additional details and examples of decorators, refer to the vignette
+#' `vignette("decorate-modules-output", package = "teal")` or the [`teal_transform_module()`] documentation.
 #'
 #' @examplesShinylive
 #' library(teal.modules.clinical)
@@ -520,7 +529,8 @@ tm_t_coxreg <- function(label,
                         conf_level = teal.transform::choices_selected(c(0.95, 0.9, 0.8), 0.95, keep_order = TRUE),
                         pre_output = NULL,
                         post_output = NULL,
-                        basic_table_args = teal.widgets::basic_table_args()) {
+                        basic_table_args = teal.widgets::basic_table_args(),
+                        decorators = NULL) {
   message("Initializing tm_t_coxreg")
   checkmate::assert_string(label)
   checkmate::assert_string(dataname)
@@ -536,6 +546,8 @@ tm_t_coxreg <- function(label,
   checkmate::assert_class(pre_output, classes = "shiny.tag", null.ok = TRUE)
   checkmate::assert_class(post_output, classes = "shiny.tag", null.ok = TRUE)
   checkmate::assert_class(basic_table_args, "basic_table_args")
+  decorators <- normalize_decorators(decorators)
+  assert_decorators(decorators, "table", null.ok = TRUE)
 
   args <- as.list(environment())
 
@@ -561,7 +573,8 @@ tm_t_coxreg <- function(label,
         parentname = parentname,
         label = label,
         na_level = na_level,
-        basic_table_args = basic_table_args
+        basic_table_args = basic_table_args,
+        decorators = decorators
       )
     ),
     datanames = teal.transform::get_extract_datanames(data_extract_list)
@@ -694,7 +707,8 @@ ui_t_coxreg <- function(id, ...) {
             fixed = a$conf_level$fixed
           )
         )
-      )
+      ),
+      ui_decorate_teal_data(ns("decorator"), decorators = select_decorators(a$decorators, "table"))
     ),
     forms = tagList(
       teal.widgets::verbatim_popup_ui(ns("rcode"), button_label = "Show R code")
@@ -720,7 +734,8 @@ srv_t_coxreg <- function(id,
                          arm_ref_comp,
                          label,
                          na_level,
-                         basic_table_args) {
+                         basic_table_args,
+                         decorators) {
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
@@ -831,10 +846,7 @@ srv_t_coxreg <- function(id,
       merge_function = "dplyr::inner_join"
     )
 
-    anl_q <- reactive({
-      data() %>%
-        teal.code::eval_code(as.expression(anl_inputs()$expr))
-    })
+    anl_q <- reactive(teal.code::eval_code(data(), as.expression(anl_inputs()$expr)))
 
     merged <- list(
       anl_input_r = anl_inputs,
@@ -1080,7 +1092,19 @@ srv_t_coxreg <- function(id,
       }
     })
 
-    table_r <- reactive(all_q()[["result"]])
+
+
+    decorated_table_q <- srv_decorate_teal_data(
+      id = "decorator",
+      data = all_q,
+      decorators = select_decorators(decorators, "table"),
+      expr = table
+    )
+
+    # Outputs to render.
+    table_r <- reactive({
+      browser()
+      decorated_table_q()[["table"]]})
 
     teal.widgets::table_with_settings_srv(
       id = "table",
@@ -1089,7 +1113,7 @@ srv_t_coxreg <- function(id,
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(all_q())),
+      verbatim_content = reactive(teal.code::get_code(req(decorated_table_q()))),
       title = "R Code for the Current (Multi-Variable) Cox proportional hazard regression model"
     )
 
@@ -1108,7 +1132,7 @@ srv_t_coxreg <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(teal.code::get_code(all_q()))
+        card$append_src(teal.code::get_code(req(decorated_table_q())))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/man/tm_t_coxreg.Rd
+++ b/man/tm_t_coxreg.Rd
@@ -24,7 +24,8 @@ tm_t_coxreg(
     TRUE),
   pre_output = NULL,
   post_output = NULL,
-  basic_table_args = teal.widgets::basic_table_args()
+  basic_table_args = teal.widgets::basic_table_args(),
+  decorators = NULL
 )
 }
 \arguments{
@@ -79,6 +80,12 @@ For example the \code{\link[shiny:helpText]{shiny::helpText()}} elements are use
 with settings for the module table. The argument is merged with option \code{teal.basic_table_args} and with default
 module arguments (hard coded in the module body).
 For more details, see the vignette: \code{vignette("custom-basic-table-arguments", package = "teal.widgets")}.}
+
+\item{decorators}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}  (\code{list} of \code{teal_transform_module}, named \code{list} of \code{teal_transform_module} or \code{NULL}) optional, if not \code{NULL}, decorator for tables or plots included in the module. When a named list of \code{teal_transform_module}, the decorators are applied to the respective output objects.
+
+Otherwise, the decorators are applied to all objects, which is equivalent as using the name \code{default}.
+
+See section "Decorating \code{tm_t_coxreg}" below for more details.}
 }
 \value{
 a \code{teal_module} object.
@@ -113,6 +120,18 @@ test will be substituted in these cases.
 \item Multi-variable is the default choice for backward compatibility.
 }
 }
+\section{Decorating \code{tm_t_coxreg}}{
+
+
+This module generates the following objects, which can be modified in place using decorators:
+\itemize{
+\item \code{table} (\code{TableTree} as created from \code{rtables::build_table})
+}
+
+For additional details and examples of decorators, refer to the vignette
+\code{vignette("decorate-modules-output", package = "teal")} or the \code{\link[=teal_transform_module]{teal_transform_module()}} documentation.
+}
+
 \examples{
 ## First example
 ## =============


### PR DESCRIPTION
Part of https://github.com/insightsengineering/teal/issues/1371

<details>
<summary>Example with decorator</summary>

```r
load_all("../teal.code")
load_all("../teal.data")
load_all("../teal")
load_all(".")
arm_ref_comp <- list(
  ACTARMCD = list(
    ref = "ARM B",
    comp = c("ARM A", "ARM C")
  ),
  ARM = list(
    ref = "B: Placebo",
    comp = c("A: Drug X", "C: Combination")
  )
)

insert_rrow_decorator <- function(default_caption = "I am a good new row", .var_to_replace = "table") {
  teal_transform_module(
    label = "New row",
    ui = function(id) shiny::textInput(shiny::NS(id, "new_row"), "New row", value = default_caption),
    server = make_teal_transform_server(
      substitute({
        .var_to_replace <- rtables::insert_rrow(.var_to_replace, rtables::rrow(new_row))
      }, env = list(.var_to_replace = as.name(.var_to_replace)))
    )
  )
}

data <- within(teal_data(), {
  ADSL <- tmc_ex_adsl
  ADTTE <- tmc_ex_adtte
})
join_keys(data) <- default_cdisc_join_keys[names(data)]

ADSL <- data[["ADSL"]]
ADTTE <- data[["ADTTE"]]

app <- init(
  data = data,
  modules = modules(
    tm_t_coxreg(
      label = "Cox Reg.",
      dataname = "ADTTE",
      arm_var = choices_selected(c("ARM", "ARMCD", "ACTARMCD"), "ARM"),
      arm_ref_comp = arm_ref_comp,
      paramcd = choices_selected(
        value_choices(ADTTE, "PARAMCD", "PARAM"), "OS"
      ),
      strata_var = choices_selected(
        c("COUNTRY", "STRATA1", "STRATA2"), "STRATA1"
      ),
      cov_var = choices_selected(
        c("AGE", "BMRKR1", "BMRKR2", "REGION1"), "AGE"
      ),
      multivariate = TRUE,
      decorators = list(insert_rrow_decorator())
    )
  )
)
if (interactive()) {
  shinyApp(app$ui, app$server)
}

## Second example
library(dplyr)

data <- teal_data()
data <- within(data, {
  ADTTE <- data.frame(
    STUDYID = "LUNG",
    AVAL = c(4, 3, 1, 1, 2, 2, 3, 1, 2),
    CNSR = c(1, 1, 1, 0, 1, 1, 0, 0, 0),
    ARMCD = factor(
      c(0, 1, 1, 1, 1, 0, 0, 0, 0),
      labels = c("ARM A", "ARM B")
    ),
    SEX = factor(
      c(0, 0, 0, 0, 1, 1, 1, 1, 1),
      labels = c("F", "M")
    ),
    INST = factor(c("A", "A", "B", "B", "A", "B", "A", "B", "A")),
    stringsAsFactors = FALSE
  )
  ADTTE <- rbind(ADTTE, ADTTE, ADTTE, ADTTE)
  ADTTE <- as_tibble(ADTTE)
  set.seed(1)
  ADTTE$INST <- sample(ADTTE$INST)
  ADTTE$AGE <- sample(seq(5, 75, 5), size = nrow(ADTTE), replace = TRUE)
  ADTTE$USUBJID <- paste("sub", 1:nrow(ADTTE), ADTTE$INST, sep = "-")
  ADTTE$PARAM <- ADTTE$PARAMCD <- "OS"
  ADSL <- subset(
    ADTTE,
    select = c("USUBJID", "STUDYID", "ARMCD", "SEX", "INST", "AGE")
  )
})

join_keys(data) <- default_cdisc_join_keys[names(data)]

ADSL <- data[["ADSL"]]
ADTTE <- data[["ADTTE"]]

## `teal` application
## ----------------
## Note that the R code exported by `Show R Code` does not include the data
## pre-processing. You will need to create the dataset as above before
## running the exported R code.

arm_ref_comp <- list(ARMCD = list(ref = "ARM A", comp = c("ARM B")))

app <- init(
  data = data,
  modules = modules(
    tm_t_coxreg(
      label = "Cox Reg.",
      dataname = "ADTTE",
      arm_var = choices_selected(c("ARMCD"), "ARMCD"),
      arm_ref_comp = arm_ref_comp,
      paramcd = choices_selected(
        value_choices(ADTTE, "PARAMCD", "PARAM"), "OS"
      ),
      strata_var = choices_selected(c("INST"), NULL),
      cov_var = choices_selected(c("SEX", "AGE"), "SEX"),
      multivariate = TRUE,
      decorators = list(insert_rrow_decorator())
    )
  )
)
if (interactive()) {
  shinyApp(app$ui, app$server)
}
```

</details>
