### PR TITLE
Introduce decorators for `tm_t_exposure`

### DIFF
--- a/R/tm_t_tte.R
+++ b/R/tm_t_tte.R
@@ -365,7 +365,6 @@ template_tte <- function(dataname = "ANL",
   y$table <- substitute(
     expr = {
       table <- rtables::build_table(lyt = lyt, df = anl, alt_counts_df = parentname)
-      table
     },
     env = list(parentname = as.name(parentname))
   )
@@ -387,6 +386,15 @@ template_tte <- function(dataname = "ANL",
 #'   pre-selected option for confidence level, each within range of (0, 1).
 #' @param event_desc_var (`character` or [data_extract_spec()])\cr variable name with the event description
 #'   information, optional.
+#' @param decorators `r roxygen_decorators_param("tm_t_tte")`
+#'
+#' @section Decorating `tm_t_tte`:
+#'
+#' This module generates the following objects, which can be modified in place using decorators:
+#' - `table` (`TableTree` - output of `rtables::build_table`)
+#'
+#' For additional details and examples of decorators, refer to the vignette
+#' `vignette("decorate-modules-output", package = "teal")` or the [`teal_transform_module()`] documentation.
 #'
 #' @details
 #' * The core functionality of this module is based on [coxph_pairwise()], [surv_timepoint()], and [surv_time()] from
@@ -493,7 +501,8 @@ tm_t_tte <- function(label,
                      na_level = default_na_str(),
                      pre_output = NULL,
                      post_output = NULL,
-                     basic_table_args = teal.widgets::basic_table_args()) {
+                     basic_table_args = teal.widgets::basic_table_args(),
+                     decorators = NULL) {
   message("Initializing tm_t_tte")
   checkmate::assert_string(label)
   checkmate::assert_string(dataname)
@@ -513,6 +522,8 @@ tm_t_tte <- function(label,
   checkmate::assert_class(pre_output, classes = "shiny.tag", null.ok = TRUE)
   checkmate::assert_class(post_output, classes = "shiny.tag", null.ok = TRUE)
   checkmate::assert_class(basic_table_args, "basic_table_args")
+  decorators <- normalize_decorators(decorators)
+  assert_decorators(decorators, null.ok = TRUE, "table")
 
   args <- as.list(environment())
 
@@ -540,7 +551,8 @@ tm_t_tte <- function(label,
         label = label,
         total_label = total_label,
         na_level = na_level,
-        basic_table_args = basic_table_args
+        basic_table_args = basic_table_args,
+        decorators = decorators
       )
     ),
     datanames = teal.transform::get_extract_datanames(data_extract_list)
@@ -724,7 +736,8 @@ ui_t_tte <- function(id, ...) {
           data_extract_spec = a$time_unit_var,
           is_single_dataset = is_single_dataset_value
         )
-      )
+      ),
+      ui_decorate_teal_data(ns("decorator"), decorators = select_decorators(a$decorators, "table")),
     ),
     forms = tagList(
       teal.widgets::verbatim_popup_ui(ns("rcode"), button_label = "Show R code")
@@ -753,7 +766,8 @@ srv_t_tte <- function(id,
                       total_label,
                       label,
                       na_level,
-                      basic_table_args) {
+                      basic_table_args,
+                      decorators) {
   with_reporter <- !missing(reporter) && inherits(reporter, "Reporter")
   with_filter <- !missing(filter_panel_api) && inherits(filter_panel_api, "FilterPanelAPI")
   checkmate::assert_class(data, "reactive")
@@ -947,13 +961,20 @@ srv_t_tte <- function(id,
       anl_q() %>% teal.code::eval_code(as.expression(unlist(my_calls)))
     })
 
-    table_r <- reactive(all_q()[["table"]])
+    decorated_table_q <- srv_decorate_teal_data(
+      id = "decorator",
+      data = all_q,
+      decorators = select_decorators(decorators, "table"),
+      expr = table
+    )
+
+    table_r <- reactive(decorated_table_q()[["table"]])
 
     teal.widgets::table_with_settings_srv(id = "table", table_r = table_r)
 
     teal.widgets::verbatim_popup_srv(
       id = "rcode",
-      verbatim_content = reactive(teal.code::get_code(all_q())),
+      verbatim_content = reactive(teal.code::get_code(req(decorated_table_q()))),
       title = label
     )
 
@@ -972,7 +993,7 @@ srv_t_tte <- function(id,
           card$append_text("Comment", "header3")
           card$append_text(comment)
         }
-        card$append_src(teal.code::get_code(all_q()))
+        card$append_src(teal.code::get_code(req(decorated_table_q())))
         card
       }
       teal.reporter::simple_reporter_srv("simple_reporter", reporter = reporter, card_fun = card_fun)

--- a/man/tm_t_tte.Rd
+++ b/man/tm_t_tte.Rd
@@ -31,7 +31,8 @@ tm_t_tte(
   na_level = default_na_str(),
   pre_output = NULL,
   post_output = NULL,
-  basic_table_args = teal.widgets::basic_table_args()
+  basic_table_args = teal.widgets::basic_table_args(),
+  decorators = NULL
 )
 }
 \arguments{
@@ -98,6 +99,12 @@ For example the \code{\link[shiny:helpText]{shiny::helpText()}} elements are use
 with settings for the module table. The argument is merged with option \code{teal.basic_table_args} and with default
 module arguments (hard coded in the module body).
 For more details, see the vignette: \code{vignette("custom-basic-table-arguments", package = "teal.widgets")}.}
+
+\item{decorators}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}}  (\code{list} of \code{teal_transform_module}, named \code{list} of \code{teal_transform_module} or \code{NULL}) optional, if not \code{NULL}, decorator for tables or plots included in the module. When a named list of \code{teal_transform_module}, the decorators are applied to the respective output objects.
+
+Otherwise, the decorators are applied to all objects, which is equivalent as using the name \code{default}.
+
+See section "Decorating \code{tm_t_tte}" below for more details.}
 }
 \value{
 a \code{teal_module} object.
@@ -120,6 +127,18 @@ filtering for \code{PARAMCD} one observation per patient is expected
 }
 }
 }
+\section{Decorating \code{tm_t_tte}}{
+
+
+This module generates the following objects, which can be modified in place using decorators:
+\itemize{
+\item \code{table} (\code{TableTree} - output of \code{rtables::build_table})
+}
+
+For additional details and examples of decorators, refer to the vignette
+\code{vignette("decorate-modules-output", package = "teal")} or the \code{\link[=teal_transform_module]{teal_transform_module()}} documentation.
+}
+
 \examples{
 data <- teal_data()
 data <- within(data, {


### PR DESCRIPTION
Part of https://github.com/insightsengineering/teal/issues/1371

<details>
<summary>Working example</summary>

```r
pkgload::load_all("../teal.modules.clinical", export_all = FALSE)

insert_rrow_decorator <- function(default_caption = "I am a good new row", .var_to_replace = "table") {
  teal_transform_module(
    label = "New row",
    ui = function(id) shiny::textInput(shiny::NS(id, "new_row"), "New row", value = default_caption),
    server = make_teal_transform_server(
      substitute({
        .var_to_replace <- rtables::insert_rrow(.var_to_replace, rtables::rrow(new_row))
      }, env = list(.var_to_replace = as.name(.var_to_replace)))
    )
  )
}

data <- teal_data()
data <- within(data, {
  ADSL <- tmc_ex_adsl
  ADTTE <- tmc_ex_adtte
})
join_keys(data) <- default_cdisc_join_keys[names(data)]

ADSL <- data[["ADSL"]]
ADTTE <- data[["ADTTE"]]

arm_ref_comp <- list(
  ACTARMCD = list(ref = "ARM B", comp = c("ARM A", "ARM C")),
  ARM = list(ref = "B: Placebo", comp = c("A: Drug X", "C: Combination"))
)

app <- init(
  data = data,
  modules = modules(
    tm_t_tte(
      label = "Time To Event Table",
      dataname = "ADTTE",
      arm_var = choices_selected(variable_choices(ADSL, c("ARM", "ARMCD", "ACTARMCD")), "ARM"),
      arm_ref_comp = arm_ref_comp,
      paramcd = choices_selected(value_choices(ADTTE, "PARAMCD", "PARAM"), "OS"),
      strata_var = choices_selected(variable_choices(ADSL, c("SEX", "BMRKR2")), "SEX"),
      time_points = choices_selected(c(182, 243), 182),
      event_desc_var = choices_selected(variable_choices(ADTTE, "EVNTDESC"), "EVNTDESC", fixed = TRUE),
      decorators = list(insert_rrow_decorator())
    )
  )
) |> shiny::runApp()
```

</details>

![image](https://github.com/user-attachments/assets/b317fa2e-44b6-446f-be53-b49c5a14bfe8)
