### PR TITLE
Fix tmc integration test - Wait for shiny app idle after fit is clicked

### DIFF
--- a/tests/testthat/test-shinytest2-tm_a_mmrm.R
+++ b/tests/testthat/test-shinytest2-tm_a_mmrm.R
@@ -62,6 +62,7 @@ app_driver_tm_a_mmrm <- function(fit_model = TRUE) {
   )
   if (fit_model) {
     app_driver$click(selector = app_driver$active_module_element("button_start"))
+    app_driver$wait_for_idle()
   }
   app_driver
 }


### PR DESCRIPTION
Potentially closes #1258

_Potentially_, because I was not able to reproduce this issue in any way to know for sure that fixes the issue. I tested in macOS, linux (docker image our CI uses), and Windows machines after installing all the packages from the GitHub main branch and was unable to reproduce this behavior.

We can close the issue after we confirm the daily integration test is resolved.

Rationale for the change:
Since this module only works after the `Fit Model` button is clicked the shinytest2 logic goes as follows:
1. Initialize the `TealAppDriver` object using the `tm_a_mmrm()` module.
2. Click the `Fit Model` button.
3. Perform the test logic:
a. Select the `Output Type` 
b. Check for errors
c. Check if output changed

![image](https://github.com/user-attachments/assets/6523679a-1921-4091-9915-381a093e1447)

I think that when we start checking for errors we spot the validation error before the output had time to render because the output type we want to select is in the first selection, which is pre-selected, and since we do not wait for input changes when the input is the same, we quickly start checking for errors and observe the validation error.
If, this is the case, this PR will fix it.