### PR TITLE
allow delayed data to pass in cs_to_des_select

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -300,8 +300,8 @@ cs_to_des_select <- function(cs, dataname, multiple = FALSE, ordered = FALSE, la
     checkmate::check_class(cs, classes = "choices_selected"),
     .var.name = cs_name
   )
-  if (!multiple && length(cs$selected) != 1 && !is.null(cs$selected)) {
-    stop(cs_name, "must only have 1 selected value")
+  if (!inherits(cs$selected, "delayed_data") && !multiple && length(cs$selected) != 1 && !is.null(cs$selected)) {
+    stop(cs_name, " must only have 1 selected value")
   }
 
   if (inherits(cs, "choices_selected")) {


### PR DESCRIPTION
FIxes #1305 

Tested under current CRAN release and development versions:
```
> packageVersion("teal.transform")
[1] '0.5.0.9018'
> packageVersion("teal.modules.clinical")
[1] '0.9.1.9042'
```