### PR TITLE
Show only datasets used

### DIFF
--- a/R/tm_g_barchart_simple.R
+++ b/R/tm_g_barchart_simple.R
@@ -190,8 +190,10 @@ tm_g_barchart_simple <- function(x = NULL,
 
   ui_args <- as.list(environment())
 
-  data_extract_list <- list(x = x, fill = fill,
-                            x_facet = x_facet, y_facet = y_facet)
+  data_extract_list <- list(
+    x = x, fill = fill,
+    x_facet = x_facet, y_facet = y_facet
+  )
 
   module(
     label = label,

--- a/R/tm_g_barchart_simple.R
+++ b/R/tm_g_barchart_simple.R
@@ -189,6 +189,10 @@ tm_g_barchart_simple <- function(x = NULL,
   )
 
   ui_args <- as.list(environment())
+
+  data_extract_list <- list(x = x, fill = fill,
+                            x_facet = x_facet, y_facet = y_facet)
+
   module(
     label = label,
     server = srv_g_barchart_simple,
@@ -204,7 +208,7 @@ tm_g_barchart_simple <- function(x = NULL,
       ggplot2_args = ggplot2_args,
       decorators = decorators
     ),
-    datanames = "all"
+    datanames = teal.transform::get_extract_datanames(data_extract_list)
   )
 }
 

--- a/R/tm_g_ci.R
+++ b/R/tm_g_ci.R
@@ -290,6 +290,13 @@ tm_g_ci <- function(label,
   checkmate::assert_class(y_var, classes = "data_extract_spec")
   checkmate::assert_class(x_var, classes = "data_extract_spec")
   checkmate::assert_class(color, classes = "data_extract_spec")
+  x_var <- teal.transform::list_extract_spec(x_var, allow_null = TRUE)
+  y_var <- teal.transform::list_extract_spec(y_var, allow_null = TRUE)
+  color <- teal.transform::list_extract_spec(color, allow_null = TRUE)
+  teal.transform::check_no_multiple_selection(x_var)
+  teal.transform::check_no_multiple_selection(y_var)
+  teal.transform::check_no_multiple_selection(color)
+
   checkmate::assert_class(conf_level, "choices_selected")
   checkmate::assert_numeric(plot_height, len = 3, any.missing = FALSE, finite = TRUE)
   checkmate::assert_numeric(plot_height[1], lower = plot_height[2], upper = plot_height[3], .var.name = "plot_height")
@@ -306,6 +313,8 @@ tm_g_ci <- function(label,
 
   args <- as.list(environment())
 
+  data_extract_list <- list(x_var = x_var, y_var = y_var, color = color)
+
   module(
     label = label,
     server = srv_g_ci,
@@ -321,7 +330,7 @@ tm_g_ci <- function(label,
     ),
     ui = ui_g_ci,
     ui_args = args,
-    datanames = "all"
+    datanames = teal.transform::get_extract_datanames(data_extract_list)
   )
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1068,7 +1068,7 @@ select_decorators <- function(decorators, scope) {
 
 #' Convert flat list of `teal_transform_module` to named lists
 #'
-#' @param decorators (list of `teal_transformodules`) to normalize.
+#' @param decorators (list of `teal_transform_module`) to normalize.
 #' @return A named list of lists with `teal_transform_module` objects.
 #' @keywords internal
 normalize_decorators <- function(decorators) {

--- a/man/normalize_decorators.Rd
+++ b/man/normalize_decorators.Rd
@@ -7,7 +7,7 @@
 normalize_decorators(decorators)
 }
 \arguments{
-\item{decorators}{(list of \code{teal_transformodules}) to normalize.}
+\item{decorators}{(list of \code{teal_transform_module}) to normalize.}
 }
 \value{
 A named list of lists with \code{teal_transform_module} objects.

--- a/man/srv_decorate_teal_data.Rd
+++ b/man/srv_decorate_teal_data.Rd
@@ -10,9 +10,9 @@ srv_decorate_teal_data(id, data, decorators, expr, expr_is_reactive = FALSE)
 ui_decorate_teal_data(id, decorators, ...)
 }
 \arguments{
-\item{id}{(\code{character(1)}) Module id}
+\item{id}{(\code{character(1)}) \code{shiny} module instance id.}
 
-\item{data}{(\verb{reactive teal_data})}
+\item{data}{(\code{reactive} returning \code{teal_data})}
 
 \item{expr}{(\code{expression} or \code{reactive}) to evaluate on the output of the decoration.
 When an expression it must be inline code. See \code{\link[=within]{within()}}

--- a/teal.modules.clinical.Rproj
+++ b/teal.modules.clinical.Rproj
@@ -1,5 +1,4 @@
 Version: 1.0
-ProjectId: 49921c94-1294-43d5-b84e-1d82b33146b1
 
 RestoreWorkspace: No
 SaveWorkspace: No

--- a/teal.modules.clinical.Rproj
+++ b/teal.modules.clinical.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: 49921c94-1294-43d5-b84e-1d82b33146b1
 
 RestoreWorkspace: No
 SaveWorkspace: No


### PR DESCRIPTION
# Pull Request

Fixes #1307 

Only `tm_g_ci` and `tm_g_barcart_simple` didn't have the datanames of the module configurable. 
I modified `tm_g_ci` and `tm_g_barcart_simple` so that only the datasets used are displayed on the module.

See the examples below where the `b` dataset is not shown on this PR.

<details>
<summary>`tm_g_ci` example</summary>

```r
devtools::load_all("../teal.modules.clinical")
data <- teal_data()
data <- within(data, {
  ADSL <- tmc_ex_adsl
  ADLB <- tmc_ex_adlb
  
  # Note that this dataset when using this module from this PR does not appear.
  b <- data.frame(r = runif(50))
})
join_keys(data) <- default_cdisc_join_keys[names(data)]

ADSL <- data[["ADSL"]]
ADLB <- data[["ADLB"]]

app <- init(
  data = data,
  modules = modules(
    tm_g_ci(
      label = "Confidence Interval Plot",
      x_var = data_extract_spec(
        dataname = "ADSL",
        select = select_spec(
          choices = c("ARMCD", "BMRKR2"),
          selected = c("ARMCD"),
          multiple = FALSE,
          fixed = FALSE
        )
      ),
      y_var = data_extract_spec(
        dataname = "ADLB",
        filter = list(
          filter_spec(
            vars = "PARAMCD",
            choices = levels(ADLB$PARAMCD),
            selected = levels(ADLB$PARAMCD)[1],
            multiple = FALSE,
            label = "Select lab:"
          ),
          filter_spec(
            vars = "AVISIT",
            choices = levels(ADLB$AVISIT),
            selected = levels(ADLB$AVISIT)[1],
            multiple = FALSE,
            label = "Select visit:"
          )
        ),
        select = select_spec(
          label = "Analyzed Value",
          choices = c("AVAL", "CHG"),
          selected = "AVAL",
          multiple = FALSE,
          fixed = FALSE
        )
      ),
      color = data_extract_spec(
        dataname = "ADSL",
        select = select_spec(
          label = "Color by variable",
          choices = c("SEX", "STRATA1", "STRATA2"),
          selected = c("STRATA1"),
          multiple = FALSE,
          fixed = FALSE
        )
      )
    )
  )
)
if (interactive()) {
  shinyApp(app$ui, app$server)
}
```

</details>

<details>
<summary>`tm_g_barchart_simple` example</summary>

```r
devtools::load_all("../teal.modules.clinical")
library(nestcolor)
library(dplyr)

data <- teal_data()
data <- within(data, {
  ADSL <- tmc_ex_adsl %>%
    mutate(ITTFL = factor("Y") %>%
             with_label("Intent-To-Treat Population Flag"))
  ADAE <- tmc_ex_adae %>%
    filter(!((AETOXGR == 1) & (AESEV == "MILD") & (ARM == "A: Drug X")))
  
  # Note that this dataset does not appear on this PR when using this module.
  b <- data.frame(r = runif(50))
})
join_keys(data) <- default_cdisc_join_keys[names(data)]

ADSL <- data[["ADSL"]]
ADAE <- data[["ADAE"]]

app <- init(
  data = data,
  modules = modules(
    tm_g_barchart_simple(
      label = "ADAE Analysis",
      x = data_extract_spec(
        dataname = "ADSL",
        select = select_spec(
          choices = variable_choices(
            ADSL,
            c(
              "ARM", "ACTARM", "SEX",
              "RACE", "ITTFL", "SAFFL", "STRATA2"
            )
          ),
          selected = "ACTARM",
          multiple = FALSE
        )
      ),
      fill = list(
        data_extract_spec(
          dataname = "ADSL",
          select = select_spec(
            choices = variable_choices(
              ADSL,
              c(
                "ARM", "ACTARM", "SEX",
                "RACE", "ITTFL", "SAFFL", "STRATA2"
              )
            ),
            selected = "SEX",
            multiple = FALSE
          )
        ),
        data_extract_spec(
          dataname = "ADAE",
          select = select_spec(
            choices = variable_choices(ADAE, c("AETOXGR", "AESEV", "AESER")),
            selected = NULL,
            multiple = FALSE
          )
        )
      ),
      x_facet = list(
        data_extract_spec(
          dataname = "ADAE",
          select = select_spec(
            choices = variable_choices(ADAE, c("AETOXGR", "AESEV", "AESER")),
            selected = "AETOXGR",
            multiple = FALSE
          )
        ),
        data_extract_spec(
          dataname = "ADSL",
          select = select_spec(
            choices = variable_choices(
              ADSL,
              c(
                "ARM", "ACTARM", "SEX",
                "RACE", "ITTFL", "SAFFL", "STRATA2"
              )
            ),
            selected = NULL,
            multiple = FALSE
          )
        )
      ),
      y_facet = list(
        data_extract_spec(
          dataname = "ADAE",
          select = select_spec(
            choices = variable_choices(ADAE, c("AETOXGR", "AESEV", "AESER")),
            selected = "AESEV",
            multiple = FALSE
          )
        ),
        data_extract_spec(
          dataname = "ADSL",
          select = select_spec(
            choices = variable_choices(
              ADSL,
              c(
                "ARM", "ACTARM", "SEX",
                "RACE", "ITTFL", "SAFFL", "STRATA2"
              )
            ),
            selected = NULL,
            multiple = FALSE
          )
        )
      )
    )
  )
)
if (interactive()) {
  shinyApp(app$ui, app$server)
}
```

</details>

I don't think the documentation of these modules needs to be updated. (The only change on the documentation is to fix a typo) 