### PR TITLE
Update teal.reporter version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Imports:
     teal.code (>= 0.5.0.9022),
     teal.data (>= 0.6.0.9025),
     teal.logger (>= 0.3.1),
-    teal.reporter (>= 0.3.1.9023),
+    teal.reporter (>= 0.4.0),
     teal.widgets (>= 0.4.2.9025),
     tern.gee (>= 0.1.5),
     tern.mmrm (>= 0.3.1),
@@ -85,7 +85,6 @@ Remotes:
     insightsengineering/teal.transform,
     insightsengineering/teal.code,
     insightsengineering/teal.data,
-    insightsengineering/teal.reporter,
     insightsengineering/teal.widgets
 Config/Needs/verdepcheck: insightsengineering/teal,
     insightsengineering/teal.slice, insightsengineering/teal.transform,


### PR DESCRIPTION
Since new version of teal.reporter is on CRAN
it's a good moment to update teal, the reverse dependency,
so that we can run tests and see if all is passing for the newly released teal.repoter.

teal will be released anyway soon and dependencies would be bumped to releases versions
https://cran.r-project.org/web/packages/teal.reporter/index.html