### PR TITLE
Duplicated decorators during an edge case of named and unnamed decorators

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1079,7 +1079,9 @@ normalize_decorators <- function(decorators) {
     if (checkmate::test_names(names(decorators))) {
       lapply(decorators, list)
     } else {
-      list(default = decorators)
+      named <- which(names(decorators) != "")
+      unnamed <- setdiff(1:length(decorators), named)
+      c(list(default = decorators[unnamed]), lapply(decorators[named], list))
     }
   } else {
     decorators

--- a/R/utils.R
+++ b/R/utils.R
@@ -1076,7 +1076,9 @@ select_decorators <- function(decorators, scope) {
 #' @keywords internal
 normalize_decorators <- function(decorators) {
   if (checkmate::test_list(decorators, "teal_transform_module")) {
-    decorators_names <- setdiff(names(decorators), "")
+    decorators_names <- names(decorators)[!names(decorators) %in% ""]
+    # Above is equivalent to decorators_names <- setdiff(names(decorators), "")
+    # but can return non-unique values. Non-unique values are checked in assert_decorators.
     if (length(decorators_names) == 0) {
       list(default = decorators)
     } else if (length(decorators_names) == length(decorators)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -1076,12 +1076,13 @@ select_decorators <- function(decorators, scope) {
 #' @keywords internal
 normalize_decorators <- function(decorators) {
   if (checkmate::test_list(decorators, "teal_transform_module")) {
-    if (checkmate::test_names(names(decorators))) {
+    decorators_names <- setdiff(names(decorators), "")
+    if (length(decorators_names) == 0) {
+      list(default = decorators)
+    } else if (length(decorators_names) == length(decorators)) {
       lapply(decorators, list)
     } else {
-      named <- which(names(decorators) != "")
-      unnamed <- setdiff(1:length(decorators), named)
-      c(list(default = decorators[unnamed]), lapply(decorators[named], list))
+      stop("All decorators should either be named or unnamed.")
     }
   } else {
     decorators


### PR DESCRIPTION
Fixes #1316

Companion in tmg https://github.com/insightsengineering/teal.modules.general/pull/835

There was an issue where decorators got duplicated when you passed a combination of named an unnamed decorators into the module. This module has 2 objects, so if you pass 1 unnamed decorators and one named, there should be only 3 decorators visible (1 unnamed passed to all 2, and one named pass to one named).

On feature branch

<img width="946" alt="image" src="https://github.com/user-attachments/assets/9285842c-3f64-472f-bf9d-845a5a7637a7" />


On main

<img width="955" alt="image" src="https://github.com/user-attachments/assets/14f5fca5-e5a5-4453-9d90-8cd2c323e91e" />




<details><summary> Code </summary>

```r
pkgload::load_all(".", export_all = FALSE)

library(nestcolor)
library(dplyr)

data <- teal_data()
data <- within(data, {
  ADAE <- tmc_ex_adae
  ADSL <- tmc_ex_adsl %>%
    filter(USUBJID %in% ADAE$USUBJID)
  
  ADAE$ASTDY <- structure(
    as.double(ADAE$ASTDY, unit = attr(ADAE$ASTDY, "units", exact = TRUE)),
    label = attr(ADAE$ASTDY, "label", exact = TRUE)
  )
})
join_keys(data) <- default_cdisc_join_keys[names(data)]

ADSL <- data[["ADSL"]]
ADAE <- data[["ADAE"]]

caption_decorator <- function(default_caption = "I am a good decorator", .var_to_replace = "plot") {
  teal_transform_module(
    label = "Caption",
    ui = function(id) shiny::textInput(shiny::NS(id, "footnote"), "Footnote", value = default_caption),
    server = make_teal_transform_server(
      substitute({
        
      }, env = list(.var_to_replace = as.name(.var_to_replace)))
    )
  )
}

head_decorator <- function(default_value = 6, .var_to_replace = "object") {
  teal_transform_module(
    label = "Head",
    ui = function(id) shiny::numericInput(shiny::NS(id, "n"), "N rows", value = default_value),
    server = make_teal_transform_server(
      substitute({
        
      }, env = list(.var_to_replace = as.name(.var_to_replace)))
    )
  )
}

app <- init(
  data = data,
  modules = modules(
    tm_g_pp_adverse_events(
      label = "Adverse Events",
      dataname = "ADAE",
      parentname = "ADSL",
      patient_col = "USUBJID",
      plot_height = c(600L, 200L, 2000L),
      aeterm = choices_selected(
        choices = variable_choices(ADAE, "AETERM"),
        selected = "AETERM"
      ),
      tox_grade = choices_selected(
        choices = variable_choices(ADAE, "AETOXGR"),
        selected = "AETOXGR"
      ),
      causality = choices_selected(
        choices = variable_choices(ADAE, "AEREL"),
        selected = "AEREL"
      ),
      outcome = choices_selected(
        choices = variable_choices(ADAE, "AEOUT"),
        selected = "AEOUT"
      ),
      action = choices_selected(
        choices = variable_choices(ADAE, "AEACN"),
        selected = "AEACN"
      ),
      time = choices_selected(
        choices = variable_choices(ADAE, "ASTDY"),
        selected = "ASTDY"
      ),
      decod = NULL,
      decorators = list(plot = caption_decorator('Marcin', 'plot'), 
                        caption_decorator('Marcin', 'plot')
                        )
    )
  )
) |> shiny::runApp()

```

</details>
