### PR TITLE
Faster check times on CI

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -42,6 +42,7 @@ jobs:
       unit-test-report-brand: >-
         https://raw.githubusercontent.com/insightsengineering/hex-stickers/main/thumbs/teal.png
       deps-installation-method: setup-r-dependencies
+      selected-shinytests: true
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
     uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
@@ -63,6 +64,7 @@ jobs:
         checking for unstated dependencies in vignettes .* NOTE
         checking top-level files .* NOTE
       deps-installation-method: setup-r-dependencies
+      selected-shinytests: true
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main


### PR DESCRIPTION
# Pull Request

Related to https://github.com/insightsengineering/coredev-tasks/issues/580, as a followup on https://github.com/insightsengineering/r.pkg.template/pull/273

By enabling these options shinytest2 tests will only run when needed. 
This will help running faster tests on PR modifying just some modules. 