### PR TITLE
1369 table should be the last object that is returned in `tm_t_events`

### DIFF
--- a/R/tm_t_events.R
+++ b/R/tm_t_events.R
@@ -438,7 +438,7 @@ template_events <- function(dataname,
 
       sort_list <- add_expr(
         sort_list,
-        quote(pruned_and_sorted_result)
+        quote(table <- pruned_and_sorted_result)
       )
     }
   }


### PR DESCRIPTION
Fixes #1369 

```r
devtools::load_all(".")
data <- teal_data()
data <- within(data, {
  ADSL <- tmc_ex_adsl
  ADAE <- tmc_ex_adae
})
join_keys(data) <- default_cdisc_join_keys[names(data)]

ADSL <- data[["ADSL"]]
ADAE <- data[["ADAE"]]

app <- init(
  data = data,
  modules = modules(
    tm_t_events(
      label = "Adverse Event Table",
      dataname = "ADAE",
      arm_var = choices_selected(c("ARM", "ARMCD"), "ARM"),
      llt = choices_selected(
        choices = variable_choices(ADAE, c("AETERM", "AEDECOD")),
        selected = c("AEDECOD")
      ),
      hlt = choices_selected(
        choices = variable_choices(ADAE, c("AEBODSYS", "AESOC")),
        selected = "AEBODSYS"
      ),
      add_total = TRUE,
      event_type = "adverse event"
    )
  )
)
if (interactive()) {
  shinyApp(app$ui, app$server)
}
```

now the table reflects pruning


https://github.com/user-attachments/assets/77bae7a9-8926-4828-b05a-0515c95f4270

