### PR TITLE
fix sorting in `tm_t_events`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,9 @@
 ### Enhancements
 * Added `denom` argument in `tm_t_binary_outcome` module.
 
+### Bug fixes
+* Fixed bug in `tm_t_events` to return sorted table.
+
 # teal.modules.clinical 0.10.0
 
 ### Enhancements

--- a/R/tm_t_events.R
+++ b/R/tm_t_events.R
@@ -841,9 +841,14 @@ srv_t_events_byterm <- function(id,
       teal.code::eval_code(merged$anl_q(), as.expression(unlist(my_calls)))
     })
 
+    table_renamed_q <- reactive({
+      req(table_q())
+      teal.code::eval_code(table_q(), "table <- pruned_and_sorted_result")
+    })
+
     decorated_table_q <- srv_decorate_teal_data(
       id = "decorator",
-      data = table_q,
+      data = table_renamed_q,
       decorators = select_decorators(decorators, "table"),
       expr = table
     )


### PR DESCRIPTION
Fixes #1393 

I took a stab at resolving the sorting issue via assigning `table <- pruned_and_sorted_result`.