### PR TITLE
chore: bump teal.logger dependency to 0.4.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -69,7 +69,7 @@ Imports:
 Suggests:
     forcats (>= 1.0.0),
     knitr (>= 1.42),
-    logger (>= 0.2.0),
+    logger (>= 0.4.0),
     lubridate (>= 1.7.9),
     nestcolor (>= 0.1.0),
     pkgload (>= 1.4.0),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Imports:
     stats,
     teal.code (>= 0.6.1),
     teal.data (>= 0.7.0),
-    teal.logger (>= 0.3.2),
+    teal.logger (>= 0.4.0),
     teal.reporter (>= 0.4.0.9004),
     teal.widgets (>= 0.4.3.9001),
     tern.gee (>= 0.1.5),


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.logger (>= 0.4.0) and removes it from Remotes.