### PR TITLE
Bump version of shiny to support `bslib` and align with `teal`'s min `shiny` version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Imports:
     rmarkdown (>= 2.23),
     rtables (>= 0.6.11),
     scales (>= 1.4.0),
-    shiny (>= 1.6.0),
+    shiny (>= 1.8.1),
     shinyjs (>= 1.10.0),
     shinyvalidate (>= 0.1.3),
     shinyWidgets (>= 0.5.1),


### PR DESCRIPTION
Bump shiny version as per the discussion https://github.com/insightsengineering/teal.widgets/pull/312#discussion_r2250985703