### PR TITLE
Fix one selector in tm_shift_by_grade

### DIFF
--- a/tests/testthat/test-shinytest2-tm_t_shift_by_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_shift_by_grade.R
@@ -85,7 +85,7 @@ testthat::test_that(
     skip_if_too_deep(5)
     app_driver <- app_driver_tm_t_shift_by_grade()
     testthat::expect_equal(
-      app_driver$get_text(".teal-modules-wrapper .module-button.active"),
+      app_driver$get_text("a.nav-link.active"),
       "Grade Laboratory Abnormality Table"
     )
     testthat::expect_equal(


### PR DESCRIPTION
# Pull Request

Part of #1440
Companion #1441

While reviewing [this PR](https://github.com/insightsengineering/teal.modules.clinical/pull/1444) I found that one e2e test on the edited files was failing.
The fix was simple, I was working on a similar fix for `g_pp` modules.

Please test it with `devtools::test(filter = "tm_t_shift_by")`