### PR TITLE
tests: fix selector to correctly validate error message

### DIFF
--- a/tests/testthat/test-shinytest2-tm_t_events_by_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_events_by_grade.R
@@ -233,7 +233,7 @@ testthat::test_that("e2e - tm_t_events_by_grade: Deselection of grade throws val
   app_driver$set_active_module_input("grade-dataset_ADAE_singleextract-select", NULL)
   testthat::expect_identical(app_driver$get_active_module_table_output("table-table-with-settings"), data.frame())
   app_driver$expect_validation_error()
-  selector <- "arm_var-dataset_ADSL_singleextract-select_input .shiny-validation-message"
+  selector <- "grade-dataset_ADAE_singleextract-select_input .shiny-validation-message"
   testthat::expect_equal(
     app_driver$get_text(app_driver$namespaces(TRUE)$module(selector)),
     "An event grade is required"


### PR DESCRIPTION
# Pull Request

Part of #1440 

There was an update on the selector.

Please run manually with:
```
devtools::load_all()
library(shinytest2)
source("tests/testthat/helper-TealAppDriver.R")
source("tests/testthat/helper-testing-depth.R")
testthat::test_file("tests/testthat/test-shinytest2-tm_t_events_by_grade")
```