### PR TITLE
Checking decorators when names don't match what is expected

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1008,15 +1008,13 @@ check_decorators <- function(x, names = NULL) { # nolint: object_name.
 
   check_message <- checkmate::check_list(x, names = "named")
 
-  if (!is.null(names)) {
-    if (isTRUE(check_message)) {
-      if (length(names(x)) != length(unique(names(x)))) {
-        check_message <- sprintf(
-          "The `decorators` must contain unique names from these names: %s.",
-          paste(names, collapse = ", ")
-        )
-      }
-    } else {
+  if (!is.null(names) && isTRUE(check_message)) {
+    if (length(names(x)) != length(unique(names(x)))) {
+      check_message <- sprintf(
+        "The `decorators` must contain unique names from these names: %s.",
+        paste(names, collapse = ", ")
+      )
+    } else if (!all(unique(names(x)) %in% names)) {
       check_message <- sprintf(
         "The `decorators` must be a named list from these names: %s.",
         paste(names, collapse = ", ")


### PR DESCRIPTION
# Pull Request

Companion of https://github.com/insightsengineering/teal.modules.general/pull/976

`check_decorators()` didn't raise the error that the decorators provided included something for an object that shouldn't be decorated!

Before:

```r
check_decorators(list(plot = teal::teal_transform_module()), "plot")
## TRUE
check_decorators(list(plot = teal::teal_transform_module()), "table")
## TRUE
```


After:

```r
check_decorators(list(plot = teal::teal_transform_module()), "plot")
## TRUE
check_decorators(list(plot = teal::teal_transform_module()), "table")
## [1] "The `decorators` must be a named list from these names: table."
```

I haven't added tests as the functions are not exported
