### PR TITLE
Fix split_choices for delayed data

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -435,13 +435,24 @@ split_col_expr <- function(compare, combine, ref, arm_var) {
 #' @note uses the regex `\\*|:` to perform the split.
 #'
 #' @return  a [teal.transform::choices_selected()] object.
+#'   When `x` is a `delayed_choices_selected` object (created with delayed data),
+#'   it is returned unchanged because the actual choices are not available
+#'   until data is resolved at runtime.
 #'
 #' @examples
 #' split_choices(choices_selected(choices = c("x:y", "a*b"), selected = all_choices()))
 #'
+#' # Also works with delayed data - returns the object unchanged
+#' split_choices(choices_selected(variable_choices("ADSL")))
+#'
 #' @export
 split_choices <- function(x) {
   checkmate::assert_class(x, "choices_selected")
+
+  if (inherits(x, "delayed_choices_selected")) {
+    return(x)
+  }
+
   checkmate::assert_character(x$choices, min.len = 1)
 
   split_x <- x

--- a/man/split_choices.Rd
+++ b/man/split_choices.Rd
@@ -13,6 +13,9 @@ object with interaction terms}
 }
 \value{
 a \code{\link[teal.transform:choices_selected]{teal.transform::choices_selected()}} object.
+When \code{x} is a \code{delayed_choices_selected} object (created with delayed data),
+it is returned unchanged because the actual choices are not available
+until data is resolved at runtime.
 }
 \description{
 Split \code{choices_selected} objects with interactions into
@@ -23,5 +26,8 @@ uses the regex \verb{\\\\*|:} to perform the split.
 }
 \examples{
 split_choices(choices_selected(choices = c("x:y", "a*b"), selected = all_choices()))
+
+# Also works with delayed data - returns the object unchanged
+split_choices(choices_selected(variable_choices("ADSL")))
 
 }

--- a/tests/testthat/test-tm_t_summary_by.R
+++ b/tests/testthat/test-tm_t_summary_by.R
@@ -137,8 +137,8 @@ testthat::describe("template_summary_by rtables output for different statistics"
           denominator = "omit",
           categorical_stats = "fraction"
         )
-        testthat::expect_all_true(
-          c("fraction.N", "fraction.Y") %in% rtables::as_result_df(session$returned()$table)$row_name
+        testthat::expect_true(
+          all(c("fraction.N", "fraction.Y") %in% rtables::as_result_df(session$returned()$table)$row_name)
         )
       }
     )
@@ -164,8 +164,8 @@ testthat::describe("template_summary_by rtables output for different statistics"
           denominator = "omit",
           categorical_stats = "count"
         )
-        testthat::expect_all_true(
-          c("count.N", "count.Y") %in% rtables::as_result_df(session$returned()$table)$row_name
+        testthat::expect_true(
+          all(c("count.N", "count.Y") %in% rtables::as_result_df(session$returned()$table)$row_name)
         )
       }
     )

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -341,6 +341,27 @@ testthat::test_that("as_numeric_from_comma_sep_str respects sep argument", {
   testthat::expect_equal(as_numeric_from_comma_sep_str("3 %% 4   %% 154.32", sep = "%%"), c(3, 4, 154.32))
 })
 
+# split_choices ----
+
+
+testthat::test_that("split_choices returns delayed_choices_selected unchanged", {
+  cs <- teal.transform::choices_selected(
+    choices = teal.transform::variable_choices("ADSL"),
+    selected = NULL
+  )
+  testthat::expect_true(inherits(cs, "delayed_choices_selected"))
+  result <- split_choices(cs)
+
+  testthat::expect_identical(result, cs)
+})
+
+testthat::test_that("split_choices rejects non-choices_selected input", {
+  testthat::expect_error(
+    split_choices("not_choices_selected"),
+    "Must inherit from class 'choices_selected'"
+  )
+})
+
 testthat::test_that("default_total_label works properly", {
   testthat::expect_silent(set_default_total_label("Total Pts"))
   testthat::expect_equal(default_total_label(), "Total Pts")


### PR DESCRIPTION
Fixes 

- https://github.com/insightsengineering/teal.modules.clinical/issues/1468

Tested with

```r
library("teal.modules.clinical")
library("teal")
tdm <- teal_data_module(    # delayed data loading via a teal_data_module()
  ui = function(id) {
    ns <- NS(id)
    actionButton(ns("submit"), label = "Load data")
  },
  server = function(id) {
    moduleServer(id, function(input, output, session) {
      eventReactive(input$submit, {   # same data loading logic as the provided example
        data <- teal_data()
        data <- within(data, {
          library(dplyr)
          ADSL <- tmc_ex_adsl
          ADQS <- tmc_ex_adqs %>%
            filter(ABLFL != "Y" & ABLFL2 != "Y") %>%
            filter(AVISIT %in% c("WEEK 1 DAY 8", "WEEK 2 DAY 15", "WEEK 3 DAY 22")) %>%
            mutate(
              AVISIT = as.factor(AVISIT),
              AVISITN = rank(AVISITN) %>%
                as.factor() %>%
                as.numeric() %>%
                as.factor() # making consecutive numeric factor
            )
        })
        join_keys(data) <- default_cdisc_join_keys[names(data)]
        data
      })
    })
  }
)

arm_ref_comp <- list(
  ARMCD = list(
    ref = "ARM B",
    comp = c("ARM A", "ARM C")
  )
)

app <- init(
  data = tdm,
  modules = modules(
    tm_t_ancova(
      label = "ANCOVA",
      dataname = "ADQS",
      avisit = choices_selected(value_choices("ADQS", "AVISIT")),
      arm_var = choices_selected(choices = variable_choices("ADSL")),
      aval_var = choices_selected(c("AVAL"), "AVAL", fixed = TRUE),
      paramcd = choices_selected(value_choices("ADQS", "PARAMCD", "PARAM")),
      cov_var = choices_selected(variable_choices("ADSL"))
    ),
    tm_a_mmrm(
      label = "MMRM",
      dataname = "ADQS",
      aval_var = choices_selected(c("AVAL", "CHG"), "AVAL"),
      id_var = choices_selected(c("USUBJID", "SUBJID"), "USUBJID"),
      arm_var = choices_selected(c("ARM", "ARMCD"), "ARM"),
      visit_var = choices_selected(c("AVISIT", "AVISITN"), "AVISIT"),
      arm_ref_comp = arm_ref_comp,
      paramcd = choices_selected(
        choices = value_choices("ADQS", "PARAMCD", "PARAM"),
        selected = "FKSI-FWB"
      ),
      cov_var = choices_selected(variable_choices("ADSL"))
    )
  )
) |> runApp()


```