### PR TITLE
Fixes problem with paramcd usage in picks' branch

### DIFF
--- a/R/utils_picks.R
+++ b/R/utils_picks.R
@@ -202,7 +202,7 @@ create_picks_helper <- function(datasets = NULL, x) {
 #'
 #' @keywords internal
 #' @noRd
-migrate_list_extract_spec_to_picks <- function(x,
+migrate_list_extract_spec_to_picks <- function(x, # nolint: object_length_linter.
                                                arg_name = "x",
                                                allow_null = TRUE) {
   checkmate::assert_string(arg_name)

--- a/R/utils_picks.R
+++ b/R/utils_picks.R
@@ -115,32 +115,57 @@ migrate_choices_selected_to_values <- function(x, # nolint: object_length_linter
 #' @noRd
 migrate_value_choices_to_picks <- function(x, # nolint: object_length_linter.
                                            multiple = NULL,
-                                           arg_name = checkmate::vname(x)) {
+                                           arg_name = checkmate::vname(x),
+                                           add_values = TRUE) {
   if (inherits(x, "picks")) {
     if (!is.null(multiple) && !identical(attr(x$values, "multiple", exact = TRUE), multiple)) {
       stop(
         sprintf("`multiple` metadata does not match the requirement for %s.", arg_name),
-        sprintf(" Please set multiple = %s in the picks object.", multiple)
+        sprintf(" Please set multiple = %s in the picks object.", multiple),
+        .call. = FALSE
       )
+    }
+
+    if (add_values && is.null(x$values)) {
+      x$values <- do.call(teal.picks::values, list(multiple = multiple)[!is.null(multiple)])
     }
     return(x)
   }
 
-  values <- migrate_choices_selected_to_values(x, multiple = multiple, arg_name = arg_name)
-  variable_name <- attr(x$choices, "var_choices", exact = TRUE)
-  if (inherits(x, "choices_selected") && is.null(variable_name)) {
+  if (inherits(x, "choices_selected")) {
+    values <- migrate_choices_selected_to_values(x, multiple = multiple, arg_name = arg_name)
+    variable_name <- attr(x$choices, "var_choices", exact = TRUE)
+    if (inherits(x, "choices_selected") && is.null(variable_name)) {
+      stop(
+        sprintf("When using choices_selected for %s", arg_name),
+        " it should have 'var_choices' attribute specifying variable choices.",
+        " Cannot convert to picks object without this information.",
+        call. = FALSE
+      )
+    }
+    teal.picks::picks(
+      teal.picks::variables(variable_name, variable_name),
+      values,
+      check_dataset = FALSE
+    )
+  }
+  if (inherits(x, "variables")) {
+    if (add_values) {
+      return(
+        teal.picks::picks(
+          x,
+          do.call(teal.picks::values, list(multiple = multiple)[!is.null(multiple)]),
+          check_dataset = FALSE
+        )
+      )
+    }
+    teal.picks::picks(x, check_dataset = FALSE)
+  } else {
     stop(
-      sprintf("When using choices_selected for %s", arg_name),
-      " it should have 'var_choices' attribute specifying variable choices.",
-      " Cannot convert to picks object without this information.",
+      sprintf("Cannot convert object of class %s to picks for %s.", class(x)[1], arg_name),
       call. = FALSE
     )
   }
-  teal.picks::picks(
-    teal.picks::variables(variable_name, variable_name),
-    values,
-    check_dataset = FALSE
-  )
 }
 
 create_picks_helper <- function(datasets = NULL, x) {

--- a/R/utils_picks.R
+++ b/R/utils_picks.R
@@ -43,7 +43,8 @@ migrate_choices_selected_to_variables <- function(x, # nolint: object_length_lin
     if (!is.null(multiple) && !identical(attr(x, "multiple", exact = TRUE), multiple)) {
       stop(
         sprintf("`multiple` metadata does not match the requirement for %s.", arg_name),
-        sprintf(" Please set multiple = %s in the picks object.", multiple)
+        sprintf(" Please set multiple = %s in the picks object.", multiple),
+        call. = FALSE
       )
     }
   }

--- a/tests/testthat/test-utils_picks.R
+++ b/tests/testthat/test-utils_picks.R
@@ -118,6 +118,16 @@ describe("migrate_value_choices_to_picks", {
     expect_s3_class(output$variables, "variables")
     expect_s3_class(output$values, "values")
   })
+
+  it("supports only variables() without adding values", {
+    output <- migrate_value_choices_to_picks(
+      teal.picks::variables("PARAMCD", "PARAMCD"),
+      add_values = FALSE
+    )
+    expect_s3_class(output, "picks")
+    expect_s3_class(output$variables, "variables")
+    expect_null(output$values)
+  })
 })
 
 describe("migrate_choices_selected_to_values", {

--- a/tests/testthat/test-utils_picks.R
+++ b/tests/testthat/test-utils_picks.R
@@ -21,6 +21,103 @@ describe("migrate_value_choices_to_picks", {
     output <- migrate_value_choices_to_picks(input)
     expect_identical(output, input)
   })
+
+  it("adds values() when ommited", {
+    output <- migrate_value_choices_to_picks(
+      teal.picks::picks(teal.picks::variables("PARAMCD", "PARAMCD"), check_dataset = FALSE)
+    )
+    expect_s3_class(output$values, "values")
+  })
+
+  it("supports picks with dataset, variables and values", {
+    output <- migrate_value_choices_to_picks(
+      teal.picks::picks(
+        teal.picks::datasets("ADSL", "ADSL"),
+        teal.picks::variables("PARAMCD", "PARAMCD"),
+        teal.picks::values(c("AEDECOD", "AESTDTC"), multiple = TRUE)
+      )
+    )
+    expect_s3_class(output, "picks")
+    expect_s3_class(output$datasets, "datasets")
+    expect_s3_class(output$variables, "variables")
+    expect_s3_class(output$values, "values")
+  })
+
+  it("suports picks with datasets and variables but no values", {
+    output <- migrate_value_choices_to_picks(
+      teal.picks::picks(
+        teal.picks::datasets("ADSL", "ADSL"),
+        teal.picks::variables("PARAMCD", "PARAMCD")
+      )
+    )
+    expect_s3_class(output, "picks")
+    expect_s3_class(output$datasets, "datasets")
+    expect_s3_class(output$variables, "variables")
+    expect_s3_class(output$values, "values")
+  })
+
+  it("suports picks with datasets and variables but no values (and without adding values)", {
+    output <- migrate_value_choices_to_picks(
+      teal.picks::picks(
+        teal.picks::datasets("ADSL", "ADSL"),
+        teal.picks::variables("PARAMCD", "PARAMCD")
+      ),
+      add_values = FALSE
+    )
+    expect_s3_class(output, "picks")
+    expect_s3_class(output$datasets, "datasets")
+    expect_s3_class(output$variables, "variables")
+    expect_null(output$values)
+  })
+
+
+  it("supports picks with variables and values, but no datasets", {
+    output <- migrate_value_choices_to_picks(
+      teal.picks::picks(
+        teal.picks::variables("PARAMCD", "PARAMCD"),
+        teal.picks::values(c("AEDECOD", "AESTDTC"), multiple = TRUE),
+        check_dataset = FALSE
+      )
+    )
+    expect_s3_class(output, "picks")
+    expect_null(output$datasets)
+    expect_s3_class(output$variables, "variables")
+    expect_s3_class(output$values, "values")
+  })
+
+  it("supports picks with only variables", {
+    output <- migrate_value_choices_to_picks(
+      teal.picks::picks(
+        teal.picks::variables("PARAMCD", "PARAMCD"),
+        check_dataset = FALSE
+      )
+    )
+    expect_s3_class(output, "picks")
+    expect_s3_class(output$variables, "variables")
+    expect_s3_class(output$values, "values")
+  })
+
+  it("supports picks with only variables (and does not add values)", {
+    output <- migrate_value_choices_to_picks(
+      teal.picks::picks(
+        teal.picks::variables("PARAMCD", "PARAMCD"),
+        check_dataset = FALSE
+      ),
+      add_values = FALSE
+    )
+    expect_s3_class(output, "picks")
+    expect_s3_class(output$variables, "variables")
+    expect_null(output$values)
+  })
+
+  it("supports only variables()", {
+    output <- migrate_value_choices_to_picks(
+      teal.picks::variables("PARAMCD", "PARAMCD")
+    )
+    expect_s3_class(output, "picks")
+    expect_s3_class(output$variables, "variables")
+    expect_s3_class(output$values, "values")
+  })
 })
 
 describe("migrate_choices_selected_to_values", {


### PR DESCRIPTION
Fixes problem detected by @m7pr with paramcd usage

### Changes description

- Only explicitly supports `picks` / `variables` and `choices_selected` in `migrate_value_choices_to_picks` call
- Adds values when needed (using given `multiple` or default in `values()` -- which is `TRUE`)