### PR TITLE
Restore behavior of tm_t_abnormality_by_wrong as it was before migration

### DIFF
--- a/R/tm_t_abnormality_by_worst_grade.R
+++ b/R/tm_t_abnormality_by_worst_grade.R
@@ -221,6 +221,7 @@ template_abnormality_by_worst_grade <- function(parentname, # nolint: object_len
 
   y$table <- substitute(
     expr = {
+      stopifnot("No common arm levels in data, please check input." = nrow(parent) > 0)
       table <- rtables::build_table(lyt = lyt, df = anl, alt_counts_df = parent)
     },
     env = list(parent = as.name(parentname))
@@ -522,32 +523,40 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint: object_length.
     anl_q <- merged_adsl_anl$data
 
     validate_checks <- reactive({
-      input_arm <- anl_selectors$arm_var()$variables$selected
       validate(
-        need(length(input_arm) == 1L, "Please select a treatment variable.")
-      )
-      validate(
-        need(
-          length(anl_selectors$id_var()$variables$selected) >= 1L,
-          "Please select a Subject Identifier."
-        ),
-        need(
-          length(anl_selectors$atoxgr_var()$variables$selected) >= 1L,
-          "Please select Analysis Toxicity Grade variable."
-        ),
-        need(
-          length(anl_selectors$worst_low_flag_var()$variables$selected) >= 1L,
-          "Please select the Worst Low Grade flag variable."
-        ),
-        need(
-          length(anl_selectors$worst_high_flag_var()$variables$selected) >= 1L,
-          "Please select the Worst High Grade flag variable."
+        teal::need_input(
+          inputId = "arm_var-variables-selected",
+          condition = length(anl_selectors$arm_var()$variables$selected) == 1L,
+          message = "Please select a treatment variable."
         )
       )
       validate(
-        need(
-          !is.null(input$worst_flag_indicator) && nzchar(input$worst_flag_indicator),
-          "Please select a value indicating the worst grade."
+        teal::need_input(
+          inputId = "id_var-variables-selected",
+          condition = length(anl_selectors$id_var()$variables$selected) >= 1L,
+          message = "Please select a Subject Identifier."
+        ),
+        teal::need_input(
+          inputId = "atoxgr_var-variables-selected",
+          condition = length(anl_selectors$atoxgr_var()$variables$selected) >= 1L,
+          message = "Please select Analysis Toxicity Grade variable."
+        ),
+        teal::need_input(
+          inputId = "worst_low_flag_var-variables-selected",
+          condition = length(anl_selectors$worst_low_flag_var()$variables$selected) >= 1L,
+          message = "Please select the Worst Low Grade flag variable."
+        ),
+        teal::need_input(
+          inputId = "worst_high_flag_var-variables-selected",
+          condition = length(anl_selectors$worst_high_flag_var()$variables$selected) >= 1L,
+          message = "Please select the Worst High Grade flag variable."
+        )
+      )
+      validate(
+        teal::need_input(
+          inputId = "worst_flag_indicator",
+          condition = !is.null(input$worst_flag_indicator),
+          message = "Please select a value indicating the worst grade."
         )
       )
 
@@ -558,9 +567,10 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint: object_length.
         pcd$values$selected
       }
       validate(
-        need(
-          length(pcd_vals) >= 1L,
-          "Please select at least one Laboratory parameter."
+        teal::need_input(
+          inputId = "paramcd-values-selected",
+          condition = length(pcd_vals) >= 1L,
+          message = "Please select at least one Laboratory parameter."
         )
       )
 
@@ -647,7 +657,9 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint: object_length.
 
       obj <- anl_q()
       teal.reporter::teal_card(obj) <- c(teal.reporter::teal_card(obj), "### Table")
-      teal.code::eval_code(obj, as.expression(unlist(my_calls)))
+      obj <- teal.code::eval_code(obj, as.expression(unlist(my_calls)))
+      validate(need(!inherits(obj, "qenv.error"), obj$message))
+      obj
     })
 
     decorated_table_q <- teal::srv_transform_teal_data(

--- a/R/tm_t_abnormality_by_worst_grade.R
+++ b/R/tm_t_abnormality_by_worst_grade.R
@@ -359,9 +359,6 @@ tm_t_abnormality_by_worst_grade <- function(label, # nolint: object_length.
   worst_high_flag_var <- migrate_choices_selected_to_variables(worst_high_flag_var)
   worst_low_flag_var <- migrate_choices_selected_to_variables(worst_low_flag_var)
   worst_flag_indicator <- migrate_choices_selected_to_values(worst_flag_indicator)
-  worst_flag_value <- as.character(worst_flag_indicator$selected)
-  checkmate::assert_character(worst_flag_value, min.len = 1L, .var.name = "worst_flag_indicator$selected")
-  worst_flag_value <- worst_flag_value[[1]]
 
   checkmate::assert_string(label)
   checkmate::assert_string(dataname)
@@ -399,7 +396,7 @@ ui_t_abnormality_by_worst_grade <- function(id, # nolint: object_length.
                                             atoxgr_var,
                                             worst_high_flag_var,
                                             worst_low_flag_var,
-                                            worst_flag_value,
+                                            worst_flag_indicator,
                                             add_total,
                                             drop_arm_levels,
                                             id_var,
@@ -444,9 +441,13 @@ ui_t_abnormality_by_worst_grade <- function(id, # nolint: object_length.
           ),
           tags$div(
             tags$label("Value Indicating Worst Grade"),
-            tags$p(
-              class = "tm-abnormality-worst-grade-worst-flag-value text-muted mb-0",
-              worst_flag_value
+            teal.widgets::optionalSelectInput(
+              ns("worst_flag_indicator"),
+              label = NULL,
+              choices = worst_flag_indicator$choices,
+              selected = if (is.function(worst_flag_indicator$selected)) NULL else worst_flag_indicator$selected,
+              multiple = FALSE,
+              fixed = teal.picks::is_pick_fixed(worst_flag_indicator)
             )
           ),
           checkboxInput(
@@ -471,7 +472,6 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint: object_length.
                                              arm_var,
                                              paramcd,
                                              atoxgr_var,
-                                             worst_flag_value,
                                              worst_low_flag_var,
                                              worst_high_flag_var,
                                              add_total,
@@ -542,6 +542,12 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint: object_length.
         need(
           length(anl_selectors$worst_high_flag_var()$variables$selected) >= 1L,
           "Please select the Worst High Grade flag variable."
+        )
+      )
+      validate(
+        need(
+          !is.null(input$worst_flag_indicator) && nzchar(input$worst_flag_indicator),
+          "Please select a value indicating the worst grade."
         )
       )
 
@@ -632,7 +638,7 @@ srv_t_abnormality_by_worst_grade <- function(id, # nolint: object_length.
         atoxgr_var = as.vector(anl_selectors$atoxgr_var()$variables$selected),
         worst_high_flag_var = as.vector(anl_selectors$worst_high_flag_var()$variables$selected),
         worst_low_flag_var = as.vector(anl_selectors$worst_low_flag_var()$variables$selected),
-        worst_flag_indicator = worst_flag_value,
+        worst_flag_indicator = input$worst_flag_indicator,
         add_total = input$add_total,
         total_label = total_label,
         drop_arm_levels = input$drop_arm_levels,

--- a/R/tm_t_binary_outcome.R
+++ b/R/tm_t_binary_outcome.R
@@ -827,7 +827,7 @@ srv_t_binary_outcome <- function(id,
           paramcd_pick$values$selected
         }
 
-        if (c(any(!is.data.frame(anl), nrow(anl) == 0L, length(aval_var) == 0L, length(paramcd_sel) == 0L))){
+        if (c(any(!is.data.frame(anl), nrow(anl) == 0L, length(aval_var) == 0L, length(paramcd_sel) == 0L))) {
           return(invisible(NULL))
         }
 

--- a/R/tm_t_summary_by.R
+++ b/R/tm_t_summary_by.R
@@ -404,7 +404,11 @@ template_summary_by <- function(parentname,
 #'       by_vars = variables(choices = c("PARAM", "AVISIT"), selected = "AVISIT"),
 #'       summarize_vars = variables(choices = c("AVAL", "CHG"), selected = "AVAL"),
 #'       useNA = "ifany",
-#'       paramcd = variables(choices = "PARAMCD")
+#'       paramcd = picks(
+#'         variables(choices = "PARAMCD"),
+#'         values(selected = "ALT"),
+#'         check_dataset = FALSE
+#'       )
 #'     )
 #'   )
 #' )
@@ -444,7 +448,7 @@ tm_t_summary_by <- function(label,
   summarize_vars <- migrate_choices_selected_to_variables(summarize_vars)
   id_var <- migrate_choices_selected_to_variables(id_var)
   denominator <- migrate_choices_selected_to_values(denominator)
-  if (!is.null(paramcd)) paramcd <- migrate_value_choices_to_picks(paramcd, multiple = FALSE)
+  if (!is.null(paramcd)) paramcd <- migrate_value_choices_to_picks(paramcd, multiple = TRUE)
 
   checkmate::assert_string(label)
   checkmate::assert_string(dataname)

--- a/man/tm_t_summary_by.Rd
+++ b/man/tm_t_summary_by.Rd
@@ -179,7 +179,11 @@ app <- init(
       by_vars = variables(choices = c("PARAM", "AVISIT"), selected = "AVISIT"),
       summarize_vars = variables(choices = c("AVAL", "CHG"), selected = "AVAL"),
       useNA = "ifany",
-      paramcd = variables(choices = "PARAMCD")
+      paramcd = picks(
+        variables(choices = "PARAMCD"),
+        values(selected = "ALT"),
+        check_dataset = FALSE
+      )
     )
   )
 )
@@ -195,8 +199,8 @@ apps implementing this module can be found.
 \section{Examples in Shinylive}{
 \describe{
   \item{example-1}{
-    \href{https://shinylive.io/r/app/#code=NobwRAdghgtgpmAXGKAHVA6ASmANGAYwHsIAXOMpMAGwEsAjAJykYE8AKcqajGIgEwCu1OAGcMBOhFoFuASgA60snGYFStAG5wABAB4AtDoBmgiOtol2cnQBUsAVQCiSpfyiko+o12oB9d09rNw8vQx0Ad1pSAAtaCHZAqFwdECUdHQBBABEAZQAZbx1SGAI-OAAPPyh+UWp0rOz8gCEikrLK6v5qeiUAX0UIACsieL8AazhWUUTQm3D+OGMoYVI-An5aUTKRscnp4Gh4GaS5AF1XaHQi+Oj2BqSdAF4dJNwGviERUWedT+ExPcIBkMiU-GtRIIYDAWKw-PQOA0QTpqFB6HBqL8FGBclCYWwdAidFgiBEdABxRhEQSoH62NEibHvYHI16hI66F7YnItJlIkEsGB+TQsX4ixi0BmAggxUYEMS-Aj3MCZLAAWSZOm56oAwtlsXI5MzWToavxwURPJiXvZnMbWQjhSwfi9xZL6N92DK5QqXkrsQAFVWZDV4LUqgBqAElclHbAaUqIMXB1HB+FjIzG4wn+RlIdCWLQAF5wJ2MF06N1SmbemS+nT+yOZfKa7E6gAS5ITOiTIlT6a5TZbYCNuZ0giTADlMhnaMsIKw+SzkagWLANmLC9WvbK6xXA8G1XqDfzBhlBoM5zp2PFyGoNNprDY0izRHEF5l0Ow0KgACSCWgUh-X8k0YbRGEGPolDAPoziAA}{Open in Shinylive}
-    \if{html}{\out{<iframe class="iframe_shinylive" src="https://shinylive.io/r/app/#code=NobwRAdghgtgpmAXGKAHVA6ASmANGAYwHsIAXOMpMAGwEsAjAJykYE8AKcqajGIgEwCu1OAGcMBOhFoFuASgA60snGYFStAG5wABAB4AtDoBmgiOtol2cnQBUsAVQCiSpfyiko+o12oB9d09rNw8vQx0Ad1pSAAtaCHZAqFwdECUdHQBBABEAZQAZbx1SGAI-OAAPPyh+UWp0rOz8gCEikrLK6v5qeiUAX0UIACsieL8AazhWUUTQm3D+OGMoYVI-An5aUTKRscnp4Gh4GaS5AF1XaHQi+Oj2BqSdAF4dJNwGviERUWedT+ExPcIBkMiU-GtRIIYDAWKw-PQOA0QTpqFB6HBqL8FGBclCYWwdAidFgiBEdABxRhEQSoH62NEibHvYHI16hI66F7YnItJlIkEsGB+TQsX4ixi0BmAggxUYEMS-Aj3MCZLAAWSZOm56oAwtlsXI5MzWToavxwURPJiXvZnMbWQjhSwfi9xZL6N92DK5QqXkrsQAFVWZDV4LUqgBqAElclHbAaUqIMXB1HB+FjIzG4wn+RlIdCWLQAF5wJ2MF06N1SmbemS+nT+yOZfKa7E6gAS5ITOiTIlT6a5TZbYCNuZ0giTADlMhnaMsIKw+SzkagWLANmLC9WvbK6xXA8G1XqDfzBhlBoM5zp2PFyGoNNprDY0izRHEF5l0Ow0KgACSCWgUh-X8k0YbRGEGPolDAPoziAA" style="height: 800px; width: 100vw; max-width: 1400px; border: 1px solid rgba(0,0,0,0.175); border-radius: .375rem; position: absolute; left: 50\%; margin-top: 30px; transform: translateX(-50\%); z-index: 1"></iframe>}}
+    \href{https://shinylive.io/r/app/#code=NobwRAdghgtgpmAXGKAHVA6ASmANGAYwHsIAXOMpMAGwEsAjAJykYE8AKcqajGIgEwCu1OAGcMBOhFoFuASgA60snGYFStAG5wABAB4AtDoBmgiOtol2cnQBUsAVQCiSpfyiko+o12oB9d09rNw8vQx0Ad1pSAAtaCHZAqFwdECUdHQBBABEAZQAZbx1SGAI-OAAPPyh+UWp0rOz8gCEikrLK6v5qeiUAX0UIACsieL8AazhWUUTQm3D+OGMoYVI-An5aUTKRscnp4Gh4GaS5AF1XaHQi+Oj2BqSdAF4dJNwGviERUWedT+ExPcIBkMiU-GtRIIYDAWKw-PQOA0QTpqFB6HBqL8FGBclCYWwdAidFgiBEdABxRhEQSoH62NEibHvYHI16hI66F7YnItJlIkEsGB+TQsX4ixi0BmAggxUYEMS-Aj3MCZLAAWSZOm56oAwtlsXI5MzWToavxwURPJiXvZnMbWQjhSwfi9xZL6N92DK5QqXkrsQAFVWZDV4LUqgBqAElclHbAaUqIMXB1HB+FjIzG4wn+RlIdCWLQAF5wJ2MF06N1SmbemS+nT+yOZfKa7E6gAS5ITOiTIlT6a5TZbYCNuZ0giTADlMhnaMsIKw+SzkagWLANr9UDJxjMxxkqx7pbK6xXA8G1Xqc8vWSLqIJAb2U+QB+Hm-GR-aTTKU+MAqEk6QvwAGLNrkLjXhkgzIlBOiDIMc46Ow8TkGoGjaNYNhpCyohxAumToOwaCoAAJIItApERxFJow2iMIMfRKGAfRnEAA}{Open in Shinylive}
+    \if{html}{\out{<iframe class="iframe_shinylive" src="https://shinylive.io/r/app/#code=NobwRAdghgtgpmAXGKAHVA6ASmANGAYwHsIAXOMpMAGwEsAjAJykYE8AKcqajGIgEwCu1OAGcMBOhFoFuASgA60snGYFStAG5wABAB4AtDoBmgiOtol2cnQBUsAVQCiSpfyiko+o12oB9d09rNw8vQx0Ad1pSAAtaCHZAqFwdECUdHQBBABEAZQAZbx1SGAI-OAAPPyh+UWp0rOz8gCEikrLK6v5qeiUAX0UIACsieL8AazhWUUTQm3D+OGMoYVI-An5aUTKRscnp4Gh4GaS5AF1XaHQi+Oj2BqSdAF4dJNwGviERUWedT+ExPcIBkMiU-GtRIIYDAWKw-PQOA0QTpqFB6HBqL8FGBclCYWwdAidFgiBEdABxRhEQSoH62NEibHvYHI16hI66F7YnItJlIkEsGB+TQsX4ixi0BmAggxUYEMS-Aj3MCZLAAWSZOm56oAwtlsXI5MzWToavxwURPJiXvZnMbWQjhSwfi9xZL6N92DK5QqXkrsQAFVWZDV4LUqgBqAElclHbAaUqIMXB1HB+FjIzG4wn+RlIdCWLQAF5wJ2MF06N1SmbemS+nT+yOZfKa7E6gAS5ITOiTIlT6a5TZbYCNuZ0giTADlMhnaMsIKw+SzkagWLANr9UDJxjMxxkqx7pbK6xXA8G1Xqc8vWSLqIJAb2U+QB+Hm-GR-aTTKU+MAqEk6QvwAGLNrkLjXhkgzIlBOiDIMc46Ow8TkGoGjaNYNhpCyohxAumToOwaCoAAJIItApERxFJow2iMIMfRKGAfRnEAA" style="height: 800px; width: 100vw; max-width: 1400px; border: 1px solid rgba(0,0,0,0.175); border-radius: .375rem; position: absolute; left: 50\%; margin-top: 30px; transform: translateX(-50\%); z-index: 1"></iframe>}}
     \if{html}{\out{<a style='height: 800px; display: block;'></a>}}
   }
 }

--- a/tests/testthat/_snaps/tm_t_abnormality_by_worst_grade.md
+++ b/tests/testthat/_snaps/tm_t_abnormality_by_worst_grade.md
@@ -41,6 +41,8 @@
       
       $table
       {
+          stopifnot(`No common arm levels in data, please check input.` = nrow(adsl) > 
+              0)
           table <- rtables::build_table(lyt = lyt, df = anl, alt_counts_df = adsl)
       }
       
@@ -88,6 +90,8 @@
       
       $table
       {
+          stopifnot(`No common arm levels in data, please check input.` = nrow(myadsl) > 
+              0)
           table <- rtables::build_table(lyt = lyt, df = anl, alt_counts_df = myadsl)
       }
       

--- a/tests/testthat/test-shinytest2-tm_t_abnormality_by_worst_grade.R
+++ b/tests/testthat/test-shinytest2-tm_t_abnormality_by_worst_grade.R
@@ -94,7 +94,7 @@ testthat::test_that(
       "WGRLOFL"
     )
     testthat::expect_equal(
-      app_driver$get_text(".tm-abnormality-worst-grade-worst-flag-value"),
+      app_driver$get_active_module_input("worst_flag_indicator"),
       "Y"
     )
   }

--- a/tests/testthat/test-tm_t_summary_by.R
+++ b/tests/testthat/test-tm_t_summary_by.R
@@ -112,9 +112,16 @@ testthat::describe("template_summary_by rtables output for different statistics"
     parentname = "ADSL",
     arm_var = teal.picks::variables(choices = "ARM", selected = "ARM", fixed = TRUE),
     by_vars = teal.picks::variables(choices = "AVISIT", selected = "AVISIT", fixed = TRUE),
-    summarize_vars = teal.picks::variables(choices = "AVALC", selected = "AVALC", fixed = TRUE),
+    summarize_vars = teal.picks::variables(choices = "AVALC", selected = "AVALC", fixed = TRUE, multiple = TRUE),
     categorical_stats = "count",
-    paramcd = teal.picks::variables(choices = "PARAMCD")
+    paramcd = suppressWarnings(
+      teal.picks::picks(
+        teal.picks::variables(choices = "PARAMCD", selected = "PARAMCD"),
+        teal.picks::values(selected = "ALT", multiple = TRUE),
+        check_dataset = FALSE
+      ),
+      classes = "pick_delayed"
+    )
   )
 
   it("adds 'fraction' to the statistics", {


### PR DESCRIPTION
# Pull Request

It fixes this comment [here](https://github.com/insightsengineering/teal.modules.clinical/pull/1470#discussion_r3246932561). We had slightly changed the behavior of the module after the migration. This PR keeps the use of `teal.picks::values` but allowing to use multiple worst flag indicators.

Test it with the example on the module:

```
devtools::load_all()
data <- teal_data()
 data <- within(data, {
   ADSL <- teal.modules.clinical::tmc_ex_adsl
   ADLB <- teal.modules.clinical::tmc_ex_adlb %>%
     dplyr::filter(!AVISIT %in% c("SCREENING", "BASELINE"))
 })
 join_keys(data) <- default_cdisc_join_keys[names(data)]

 ADSL <- data[["ADSL"]]
 ADLB <- data[["ADLB"]]

 app <- init(
   data = data,
   modules = modules(
     tm_t_abnormality_by_worst_grade(
       label = "Laboratory Test Results with Highest Grade Post-Baseline",
       dataname = "ADLB",
       arm_var = choices_selected(
         choices = variable_choices(ADSL, subset = c("ARM", "ARMCD")),
         selected = "ARM"
       ),
       paramcd = choices_selected(
         choices = value_choices(ADLB, "PARAMCD", "PARAM"),
         selected = c("ALT", "CRP", "IGA")
       ),
       worst_flag_indicator = teal.transform::choices_selected(c("Y", "N")),
       add_total = FALSE
     )
   ),
   filter = teal_slices(
     teal_slice("ADSL", "SAFFL", selected = "Y"),
     teal_slice("ADLB", "ONTRTFL", selected = "Y")
   )
 )
 if (interactive()) {
   shinyApp(app$ui, app$server)
 }
 ```
 You should see the module working and two options available.
 Note: If you select "N" as worst flag indicator it will fail to compute the table. (It says it is computing and it never finishes). But it also happens in the example module before migration, that allowed multiple values and the "N" just does not work. It needs the right data that can allow multiple correct worst flag indicator. But the example proves that the multiple values are in the UI and used by the module.